### PR TITLE
Tooling for dumping and loading translations into JSON objects

### DIFF
--- a/language_dump.py
+++ b/language_dump.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import json
+# from pprint import pprint
+
+# Command line arguments.
+parser = argparse.ArgumentParser(description='Dump translations for OpenRCT2\'s JSON objects.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('-o', '--objects', default="objects", help='JSON objects directory')
+parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against')
+parser.add_argument('-d', '--dumpfile', help='Translation file to export to', required=True)
+parser.add_argument('-l', '--language', help='Language that should be extracted, e.g. ja-JP', required=True)
+args = parser.parse_args()
+
+language_to_extract = args.language
+fallback_language = args.fallback
+dump_file_name = args.dumpfile
+
+strings_by_object = {}
+
+for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
+    with open(filename) as file:
+        data = json.load(file)
+
+        if not 'strings' in data:
+            print("No strings in " + data['id'] + ", skipping")
+            continue
+
+        for string_key in data['strings']:
+            if not data['id'] in strings_by_object:
+                strings_by_object[data['id']] = {}
+
+            if language_to_extract in data['strings'][string_key]:
+                print("Found existing translation for " + data['id'])
+                strings_by_object[data['id']][string_key] = data['strings'][string_key][language_to_extract]
+            elif fallback_language in data['strings'][string_key]:
+                print("No existing translation for " + data['id'] + " yet, using English")
+                strings_by_object[data['id']][string_key] = data['strings'][string_key][fallback_language]
+            else:
+                print("No existing translation for " + data['id'] + " yet, but no English string either -- skipping")
+                # pprint(data)
+
+out = open(dump_file_name, "w")
+json.dump(strings_by_object, out, indent=4, ensure_ascii=False, separators=(',', ': '))
+out.write("\n")
+out.close()

--- a/language_load.py
+++ b/language_load.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import json
+import re
+
+# Command line arguments.
+parser = argparse.ArgumentParser(description='Imports translations into OpenRCT2\'s JSON objects.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('-o', '--objects', default="objects", help='JSON objects directory')
+parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against')
+parser.add_argument('-i', '--input', help='Translation dump file to import from', required=True)
+parser.add_argument('-l', '--language', help='Language that is being translated, e.g. ja-JP', required=True)
+args = parser.parse_args()
+
+language_to_import = args.language
+fallback_language = args.fallback
+
+in_file = open(args.input)
+strings_by_object = json.load(in_file)
+in_file.close()
+
+class LessVerboseJSONEncoder(json.JSONEncoder):
+    def iterencode(self, o, _one_shot=False):
+        list_lvl = 0
+        for s in super(LessVerboseJSONEncoder, self).iterencode(o, _one_shot=_one_shot):
+            if s.startswith('['):
+                list_lvl += 1
+                s = re.sub(r'\n\s*', '', s).strip()
+            elif 0 < list_lvl:
+                s = re.sub(r'\n\s*', ' ', s).strip()
+                if s and s[-1] == ',':
+                    s = s[:-1] + self.item_separator
+                elif s and s[-1] == ':':
+                    s = s[:-1] + self.key_separator
+            if s.endswith(']'):
+                list_lvl -= 1
+            yield s
+
+for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
+    file = open(filename)
+    data = json.load(file)
+    file.close()
+
+    if not 'strings' in data:
+        print("No strings in " + data['id'] + " -- skipping")
+        continue
+
+    if not data['id'] in strings_by_object:
+        print("No translations for " + data['id'] + " in dump file -- skipping")
+        continue
+
+    updated = False
+    for string_key in data['strings']:
+
+        if not string_key in strings_by_object[data['id']]:
+            print("No translation for " + data['id'] + " string '" + string_key + "' in dump file -- skipping")
+            continue
+
+        if not fallback_language in data['strings'][string_key]:
+            print("No en-GB reference for " + data['id'] + " string '" + string_key + "' in dump file -- probably shouldn't exist; skipping")
+            continue
+
+        if not language_to_import in data['strings'][string_key]:
+            if strings_by_object[data['id']][string_key] == data['strings'][string_key][fallback_language]:
+                # TODO: Is this desirable behaviour?
+                print("Translation for " + data['id'] + " string '" + string_key + "' is identical to en-GB -- skipping")
+                continue
+
+            print("Adding " + data['id'] + " string '" + string_key + "'")
+            data['strings'][string_key][language_to_import] = strings_by_object[data['id']][string_key]
+            updated = True
+        else:
+            if strings_by_object[data['id']][string_key] == data['strings'][string_key][language_to_import]:
+                print("Translation for " + data['id'] + " string '" + string_key + "' has not changed -- skipping")
+                continue
+
+            print("Updating " + data['id'] + " string '" + string_key + "'")
+            data['strings'][string_key][language_to_import] = strings_by_object[data['id']][string_key]
+            updated = True
+
+    if updated:
+        file = open(filename, "w")
+        json.dump(data, file, indent=4, separators=(',', ': '), ensure_ascii=False, cls=LessVerboseJSONEncoder)
+        file.write("\n")
+        file.close()


### PR DESCRIPTION
Currently, adding new strings to JSON objects is quite a pain for translators. In this PR, I would like to propose tooling to make life a little easier for them.

#### language_dump.py

This script outputs all existing strings for one particular language, falling back to en-GB if there are no translations yet. Example output:

```
$ ./language_dump.py -d out.json -l ja-JP > /dev/null
$ head out.json 
{
    "rct2.roof12": {
        "name": "屋根"
    },
    "rct2.tl1": {
        "name": "木"
    },
    "rct2.tt1": {
        "name": "ローマ寺院"
    },
```

A dump of all current en-GB strings may be found here for reference: https://pastebin.com/jLYjPyfL

#### language_load.py

This script does the reverse: it takes a JSON dump file and writes the new strings to the appropriate JSON object files. If the proposed string is identical to en-GB, it is omitted.

Caveat: the object files currently have non-standard indentation with regards to arrays. I have extended Python's JSON encoder to compensate, only to find we are inconsistent about it. This requires some more work, either way.