### PR TITLE
Rename fries to chips for UK spelling

### DIFF
--- a/objects/rct2/ride/rct2.chpsh2.json
+++ b/objects/rct2/ride/rct2.chpsh2.json
@@ -19,7 +19,8 @@
     "images": ["$RCT2:OBJDATA/CHPSH2.DAT[0..6]"],
     "strings": {
         "name": {
-            "en-GB": "Fries Stall",
+            "en-GB": "Chips Stall",
+            "en-US": "Fries Stall",
             "fr-FR": "Stand de frites",
             "de-DE": "Pommes Frites-Stand",
             "es-ES": "Puesto de patatas fritas",
@@ -36,7 +37,8 @@
             "ru-RU": "Картошка"
         },
         "description": {
-            "en-GB": "A stall selling fries",
+            "en-GB": "A stall selling chips",
+            "en-US": "A stall selling fries",
             "fr-FR": "Boutique vendant des frites",
             "de-DE": "Ein Stand, an dem Pommes Frites verkauft werden",
             "es-ES": "Puesto que vende patatas fritas",


### PR DESCRIPTION
Reference: http://grammarist.com/usage/chips-vs-fries/

There was some talk in the Roller Coaster & Friends Discord server about whether is should be "Chip Stall" or "Chips Stall" (it's called Chip Hut in RCT1). Soemone with an English degree said there's not a definitive answer to which one is more correct.

Does this need to bump the version somewhere, or is that only for releases?