### PR TITLE
it-IT new station translations

### DIFF
--- a/objects/official/station/openrct2.station.noentrance.json
+++ b/objects/official/station/openrct2.station.noentrance.json
@@ -13,7 +13,7 @@
             "fr-FR": "Pas d'entrée",
             "de-DE": "Kein Eingang",
             "es-ES": "Entrada invisible",
-            "it-IT": "Nessuna entrata",
+            "it-IT": "Senza entrata",
             "nl-NL": "Geen ingang",
             "sv-SE": "Ingen ingång",
             "ko-KR": "입구 없음",

--- a/objects/official/station/openrct2.station.noplatformnoentrance.json
+++ b/objects/official/station/openrct2.station.noplatformnoentrance.json
@@ -12,6 +12,7 @@
     "strings": {
         "name": {
             "en-GB": "No entrance, no platform",
+            "it-IT": "Senza entrata, senza piattaforma",
             "nl-NL": "Geen ingang, geen perron",
             "ko-KR": "감추기, 승강장도 감추기",
             "zh-CN": "没有入口, 没有站台"

--- a/objects/rct2/station/rct2.station.abstract.json
+++ b/objects/rct2/station/rct2.station.abstract.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Abstract",
+            "it-IT": "Astratto",
             "ko-KR": "추상적",
             "zh-CN": "摘要"
         }

--- a/objects/rct2/station/rct2.station.canvas.json
+++ b/objects/rct2/station/rct2.station.canvas.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Canvas Tent",
+            "it-IT": "Tenda di tela",
             "nl-NL": "Canvastent",
             "ko-KR": "캔버스 텐트",
             "zh-CN": "帆布帐篷"

--- a/objects/rct2/station/rct2.station.castlebrown.json
+++ b/objects/rct2/station/rct2.station.castlebrown.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Castle (Brown)",
+            "it-IT": "Castello (marrone)",
             "nl-NL": "Kasteel (bruin)",
             "ko-KR": "성 (갈색)",
             "zn-CN": "城堡 (棕色)"

--- a/objects/rct2/station/rct2.station.castlegrey.json
+++ b/objects/rct2/station/rct2.station.castlegrey.json
@@ -16,6 +16,7 @@
         "name": {
             "en-GB": "Castle (Grey)",
             "en-US": "Castle (Gray)",
+            "it-IT": "Castello (grigio)",
             "nl-NL": "Kasteel (grijs)",
             "ko-KR": "성 (회색)",
             "zh-CN": "城堡 (灰色)"

--- a/objects/rct2/station/rct2.station.classical.json
+++ b/objects/rct2/station/rct2.station.classical.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Classical / Roman",
+            "it-IT": "Classico / Romano",
             "nl-NL": "Klassiek / Romeins",
             "ko-KR": "고전 / 로마",
             "zh-CN": "经典 / 罗马"

--- a/objects/rct2/station/rct2.station.jungle.json
+++ b/objects/rct2/station/rct2.station.jungle.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Jungle",
+            "it-IT": "Giungla",
             "ko-KR": "정글",
             "zh-CN": "丛林"
         }

--- a/objects/rct2/station/rct2.station.log.json
+++ b/objects/rct2/station/rct2.station.log.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Log Cabin",
+            "it-IT": "Capanna di legno",
             "nl-NL": "Blokhut",
             "ko-KR": "통나무",
             "zh-CN": "木屋"

--- a/objects/rct2/station/rct2.station.pagoda.json
+++ b/objects/rct2/station/rct2.station.pagoda.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Pagoda",
+            "it-IT": "Pagoda",
             "nl-NL": "Pagode",
             "ko-KR": "탑",
             "zh-CN": "塔"

--- a/objects/rct2/station/rct2.station.plain.json
+++ b/objects/rct2/station/rct2.station.plain.json
@@ -13,6 +13,7 @@
     "strings": {
         "name": {
             "en-GB": "Plain",
+            "it-IT": "Standard",
             "nl-NL": "Standaard",
             "ko-KR": "일반",
             "zh-CN": "平地"

--- a/objects/rct2/station/rct2.station.snow.json
+++ b/objects/rct2/station/rct2.station.snow.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Snow / Ice",
+            "it-IT": "Neve / Ghiaccio",
             "nl-NL": "Sneeuw / IJs",
             "ko-KR": "눈 / 얼음",
             "zh-CN": "雪 / 冰"

--- a/objects/rct2/station/rct2.station.space.json
+++ b/objects/rct2/station/rct2.station.space.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Space",
+            "it-IT": "Spazio",
             "nl-NL": "Ruimte",
             "ko-KR": "우주",
             "zh-CN": "太空"

--- a/objects/rct2/station/rct2.station.wooden.json
+++ b/objects/rct2/station/rct2.station.wooden.json
@@ -16,6 +16,7 @@
     "strings": {
         "name": {
             "en-GB": "Wooden",
+            "it-IT": "Legno",
             "nl-NL": "Hout",
             "ko-KR": "나무",
             "zh-CN": "木质"


### PR DESCRIPTION
New it-IT translations as per OpenRCT2/Localisation#1625

I added my new strings in the language code alphabetical order, however not every file is currently fully ordered. I think that the alphabetical order makes sense because:
1) it's cleaner
2) you don't have to edit two lines to add the comma whenever you add a new translation (except if your language is the last one in the alphabetical order).