### PR TITLE
ko-KR: Fix translation for 'Panda'

### DIFF
--- a/objects/official/footpath_item/rct2.dlc.litterpa.json
+++ b/objects/official/footpath_item/rct2.dlc.litterpa.json
@@ -24,7 +24,7 @@
             "it-IT": "Cestino dei rifiuti a panda",
             "nl-NL": "Vuilnisbak in pandavorm",
             "sv-SE": "Pandaskräpkorg",
-            "ko-KR": "팬더 휴지통",
+            "ko-KR": "판다 휴지통",
             "zh-TW": "熊貓垃圾桶",
             "pt-BR": "Lixeira de Panda",
             "ar-EG": "صندوق بريد الباندا"

--- a/objects/official/ride/rct2.dlc.zpanda.json
+++ b/objects/official/ride/rct2.dlc.zpanda.json
@@ -74,7 +74,7 @@
             "it-IT": "Treni panda",
             "nl-NL": "Pandatreinen",
             "sv-SE": "Pandatåg",
-            "ko-KR": "팬더 열차",
+            "ko-KR": "판다 열차",
             "zh-TW": "熊貓列車",
             "pt-BR": "Trens Panda",
             "ar-EG": "قطارات الباندا"
@@ -87,7 +87,7 @@
             "it-IT": "Treni da ottovolante con carrozze a forma di teneri panda",
             "nl-NL": "Achtbaantrein met kleine karretjes in de vorm van een panda.",
             "sv-SE": "Berg- och dalbanetåg med gosiga pandavagnar",
-            "ko-KR": "귀여운 팬더 차량이 달린 롤러코스터 열차",
+            "ko-KR": "귀여운 판다 차량이 달린 롤러코스터 열차",
             "zh-TW": "雲霄飛車列車是逗人喜愛的熊貓車輛",
             "pt-BR": "Trens de montanha-russa com vagões em forma de panda",
             "ar-EG": "قطار أفعوانية مع عربات بشكل الباندا المحبب"

--- a/objects/official/scenery_group/rct2.dlc.scgpanda.json
+++ b/objects/official/scenery_group/rct2.dlc.scgpanda.json
@@ -23,7 +23,7 @@
             "it-IT": "Tema panda",
             "nl-NL": "Pandathema",
             "sv-SE": "Pandatema",
-            "ko-KR": "팬더 테마 공원",
+            "ko-KR": "판다 테마 공원",
             "zh-TW": "熊貓主題區",
             "pt-BR": "Temática Panda",
             "ar_EG": "ثيم الباندا"

--- a/objects/official/scenery_small/rct2.dlc.bigpanda.json
+++ b/objects/official/scenery_small/rct2.dlc.bigpanda.json
@@ -25,7 +25,7 @@
             "it-IT": "Panda gigante",
             "nl-NL": "Reuzenpanda",
             "sv-SE": "Jättepanda",
-            "ko-KR": "자이언트 팬더",
+            "ko-KR": "자이언트 판다",
             "zh-TW": "巨大的熊貓",
             "pt-BR": "Panda Gigante",
             "ar-EG": "الباندا العملاق"

--- a/objects/rct2ww/scenery_small/rct2.ww.adpanda.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.adpanda.json
@@ -27,7 +27,7 @@
             "sv-SE": "Fullvuxen panda",
             "zh-CN": "成人期的熊猫",
             "cs-CZ": "Dospělá panda",
-            "ko-KR": "어른 팬더",
+            "ko-KR": "어른 판다",
             "pl-PL": "Dorosła panda",
             "ru-RU": "Панда",
             "pt-BR": "Panda Adulto"

--- a/objects/rct2ww/scenery_small/rct2.ww.babpanda.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.babpanda.json
@@ -26,7 +26,7 @@
             "sv-SE": "Babypanda",
             "zh-CN": "幼儿期的熊猫",
             "cs-CZ": "Malá panda",
-            "ko-KR": "아기 팬더",
+            "ko-KR": "아기 판다",
             "pl-PL": "Mała panda",
             "ru-RU": "Панда",
             "pt-BR": "Panda Filhote"


### PR DESCRIPTION
```팬더``` is a wrong expression for Panda, right one is ```판다```