### PR TITLE
Make English vehicle names more consistent

### DIFF
--- a/objects/rct2/ride/rct2.arrx.json
+++ b/objects/rct2/ride/rct2.arrx.json
@@ -86,7 +86,7 @@
     "images": ["$RCT2:OBJDATA/ARRX.DAT[0..28226]"],
     "strings": {
         "name": {
-            "en-GB": "Multi-Dimension Coaster Train",
+            "en-GB": "Multi-Dimension Coaster Trains",
             "fr-FR": "Train multidimension",
             "de-DE": "Mehrdimensionaler-Achterbahnzug",
             "es-ES": "Montaña Rusa Multi-Dimensión",

--- a/objects/rct2/ride/rct2.intst.json
+++ b/objects/rct2/ride/rct2.intst.json
@@ -102,7 +102,7 @@
             "ru-RU": "Гига-Горки"
         },
         "description": {
-            "en-GB": "A giant steel roller coaster capable of smooth drops and hills of over 300ft",
+            "en-GB": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
             "fr-FR": "Montagnes russes géantes proposant des chutes régulières depuis des collines dépassant les 100 mètres d'altitude",
             "de-DE": "Eine gigantische Stahlachterbahn mit gemäßigten Gefällen und Anstiegen von über 90 Meter",
             "es-ES": "Una montaña rusa gigante capaz de caídas suaves y subidas de más de 300 pies",

--- a/objects/rct2/ride/rct2.pmt1.json
+++ b/objects/rct2/ride/rct2.pmt1.json
@@ -83,7 +83,7 @@
     "images": ["$RCT2:OBJDATA/PMT1.DAT[0..1822]"],
     "strings": {
         "name": {
-            "en-GB": "Powered mine train",
+            "en-GB": "Powered Mine Trains",
             "fr-FR": "Mineur",
             "de-DE": "Minenbahn",
             "es-ES": "Trenes Mineros",

--- a/objects/rct2/ride/rct2.rapboat.json
+++ b/objects/rct2/ride/rct2.rapboat.json
@@ -59,7 +59,7 @@
     "images": ["$RCT2:OBJDATA/RAPBOAT.DAT[0..362]"],
     "strings": {
         "name": {
-            "en-GB": "River Rapids",
+            "en-GB": "River Rapids Boats",
             "fr-FR": "Rapides",
             "de-DE": "Stromschnellen",
             "es-ES": "Rápidos",

--- a/objects/rct2/ride/rct2.sbox.json
+++ b/objects/rct2/ride/rct2.sbox.json
@@ -42,7 +42,7 @@
     "images": ["$RCT2:OBJDATA/SBOX.DAT[0..386]"],
     "strings": {
         "name": {
-            "en-GB": "Soap boxes",
+            "en-GB": "Soap Boxes",
             "fr-FR": "Savonneuse",
             "de-DE": "Seifenkisten-Rennwagen",
             "es-ES": "Carreras de Jaboneras",

--- a/objects/rct2/ride/rct2.scht1.json
+++ b/objects/rct2/ride/rct2.scht1.json
@@ -84,7 +84,7 @@
     "images": ["$RCT2:OBJDATA/SCHT1.DAT[0..4322]"],
     "strings": {
         "name": {
-            "en-GB": "Roller Coaster Trains",
+            "en-GB": "Looping Roller Coaster Trains",
             "fr-FR": "Trains de montagnes russes",
             "de-DE": "Achterbahnzüge",
             "es-ES": "Trenes de Montaña Rusa",

--- a/objects/rct2/ride/rct2.spdrcr.json
+++ b/objects/rct2/ride/rct2.spdrcr.json
@@ -68,7 +68,7 @@
             "ru-RU": "Спиральные горки"
         },
         "description": {
-            "en-GB": "A compact steel-tracked roller coaster with a spiral lift hill and cars with in-line seating",
+            "en-GB": "Compact roller coaster trains with cars with in-line seating",
             "fr-FR": "Montagnes russes compactes et métalliques avec une remontée en spirale et des voitures disposant de sièges en ligne",
             "de-DE": "Eine kompakte Stahlachterbahn mit einem Spirallifthügel und Wagen mit Sitzen in einer Reihe",
             "es-ES": "Una montaña rusa pequeña de acero con una subida en espiral y vagones con asientos en línea",

--- a/objects/rct2/ride/rct2.ssc1.json
+++ b/objects/rct2/ride/rct2.ssc1.json
@@ -200,7 +200,7 @@
     "images": ["$RCT2:OBJDATA/SSC1.DAT[0..23]"],
     "strings": {
         "name": {
-            "en-GB": "Launched Freefall car",
+            "en-GB": "Launched Freefall Car",
             "fr-FR": "Chute libre lancée",
             "de-DE": "Hochgeschossener Freefallwagen",
             "es-ES": "Caída Libre Propulsada",

--- a/objects/rct2/ride/rct2.togst.json
+++ b/objects/rct2/ride/rct2.togst.json
@@ -122,7 +122,7 @@
             "ru-RU": "Стоячие горки"
         },
         "description": {
-            "en-GB": "A looping roller coaster where the riders ride in a standing position",
+            "en-GB": "Roller coaster trains in which the riders ride in a standing position",
             "fr-FR": "Grand huit que les passagers parcourent debout",
             "de-DE": "Eine Looping-Achterbahn, bei der sich die Fahrgäste in einer stehenden Position befinden",
             "es-ES": "Una montaña rusa en el que los pasajeros permanecen de pie",

--- a/objects/rct2/ride/rct2.utcarr.json
+++ b/objects/rct2/ride/rct2.utcarr.json
@@ -91,7 +91,7 @@
             "ru-RU": "Твистер-Кар (реверс.)"
         },
         "description": {
-            "en-GB": "Roller coaster cars capable of heartline twists",
+            "en-GB": "Roller coaster cars capable of heartline twists, starting reversed",
             "fr-FR": "Voiture de montagnes russes capable de passer dans des inversions à 360°",
             "de-DE": "Achterbahnwagen, mit denen Heartline-Twists möglich sind",
             "es-ES": "Montaña rusa con vagones capaces de giros a media altura",

--- a/objects/rct2/ride/rct2.vreel.json
+++ b/objects/rct2/ride/rct2.vreel.json
@@ -44,7 +44,7 @@
     "images": ["$RCT2:OBJDATA/VREEL.DAT[0..362]"],
     "strings": {
         "name": {
-            "en-GB": "Virginia Reel tubs",
+            "en-GB": "Virginia Reel Tubs",
             "de-DE": "Virginia-Reel-Wagen",
             "es-ES": "Danza de Virginia",
             "it-IT": "Bobine della Virginia",

--- a/objects/rct2tt/ride/rct2.tt.1920racr.json
+++ b/objects/rct2tt/ride/rct2.tt.1920racr.json
@@ -84,7 +84,7 @@
             "ru-RU": "Машинки 1920гг"
         },
         "description": {
-            "en-GB": "Riders race each other in a 1920's Race Car themed Go-Kart",
+            "en-GB": "Riders race each other in 1920's race car themed go-karts",
             "fr-FR": "Les passagers font la course à bord de karts représentant des voitures des années folles",
             "de-DE": "Die Fahrer fahren Rennen mit Gokarts aus den Zwanzigern.",
             "es-ES": "Los usuarios compiten en karts con forma de coches de carreras de los años 20.",

--- a/objects/rct2tt/ride/rct2.tt.battrram.json
+++ b/objects/rct2tt/ride/rct2.tt.battrram.json
@@ -66,7 +66,7 @@
             "ru-RU": "Таранные горки"
         },
         "description": {
-            "en-GB": "A compact steel-tracked roller coaster with a spiral lift hill and cars with in-line seating",
+            "en-GB": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
             "fr-FR": "Montagnes russes compactes et métalliques avec une remontée en spirale et des voitures disposant de sièges en ligne",
             "de-DE": "Eine kompakte Achterbahn auf Stahlträgern mit spiralförmigem Lifthügel und Wagen mit einreihigen Einsitzern.",
             "es-ES": "Una montaña rusa compacta, de metal, con una subida en espiral y coches con asientos en línea.",

--- a/objects/rct2tt/ride/rct2.tt.blckdeth.json
+++ b/objects/rct2tt/ride/rct2.tt.blckdeth.json
@@ -60,7 +60,7 @@
             "ru-RU": "Чёрная Смерть"
         },
         "description": {
-            "en-GB": "Riders career down a twisting track in Rat-shaped cars guided only by the curvature and banking of the semi-circular track",
+            "en-GB": "Riders career down a twisting track in rat-shaped cars guided only by the curvature and banking of the semi-circular track",
             "fr-FR": "Les passagers descendent un parcours alambiqué à bord d'une grande voiture en forme de rat dirigée uniquement par les courbes et l'inclinaison de la voie semi-circulaire",
             "de-DE": "Die Fahrer rasen in Ratten-artigen Wagen eine gewundene Strecke hinab, wobei sie nur durch die Kurvenführung der halbrunden Strecke geführt werden.",
             "es-ES": "Los usuarios recorren, en coches en forma de rata, una ruta guiada únicamente por la curvatura y el desnivel del recorrido semicircular.",

--- a/objects/rct2tt/ride/rct2.tt.cavmncar.json
+++ b/objects/rct2tt/ride/rct2.tt.cavmncar.json
@@ -84,7 +84,7 @@
             "ru-RU": "Пещ. машины"
         },
         "description": {
-            "en-GB": "Riders race each other in Stone-Age Go-Karts",
+            "en-GB": "Riders race each other in Stone Age go-karts",
             "fr-FR": "Les passagers font la course à bord de karts préhistoriques",
             "de-DE": "Die Fahrer fahren Rennen mit Gokarts aus der Steinzeit",
             "es-ES": "Los usuarios compiten en los karts de la edad de piedra",

--- a/objects/rct2tt/ride/rct2.tt.dinoeggs.json
+++ b/objects/rct2tt/ride/rct2.tt.dinoeggs.json
@@ -412,7 +412,7 @@
             "ru-RU": "Динозавр"
         },
         "description": {
-            "en-GB": "Riders ride in pairs, in themed seats rotating around an animated mother Dinosaur.",
+            "en-GB": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
             "fr-FR": "Les passagers sont assis par deux dans des sièges thématiques et font le tour d'une maman dinosaure animée.",
             "de-DE": "Die Fahrgäste fahren zu zweit in Sitzen, die um eine animierte Dinosauriermama rotieren.",
             "es-ES": "Los usuarios montan en parejas, en asientos ambientados que giran alrededor de una madre dinosaurio animada.",

--- a/objects/rct2tt/ride/rct2.tt.figtknit.json
+++ b/objects/rct2tt/ride/rct2.tt.figtknit.json
@@ -47,7 +47,7 @@
     "images": ["$RCT2:OBJDATA/FIGTKNIT.DAT[0..130]"],
     "strings": {
         "name": {
-            "en-GB": "Fighting Knights Dodgem Cars",
+            "en-GB": "Fighting Knights Dodgems",
             "fr-FR": "Auto-tamponneuses des chevaliers",
             "de-DE": "Kampfritter-Autoskooterwagen",
             "es-ES": "Coches de choque Caballeros en combate",
@@ -62,7 +62,7 @@
             "ru-RU": "Рыцари"
         },
         "description": {
-            "en-GB": "Riders joust on Horse-themed dodgem cars",
+            "en-GB": "Riders joust on horse-themed dodgem cars",
             "fr-FR": "Les passagers participent à un tournoi médiéval d'auto-tamponneuses",
             "de-DE": "Die Fahrer kämpfen im Autoskooter auf Pferdewagen.",
             "es-ES": "Los usuarios se suben en coches de choque decorados como caballos.",

--- a/objects/rct2tt/ride/rct2.tt.flwrpowr.json
+++ b/objects/rct2tt/ride/rct2.tt.flwrpowr.json
@@ -60,7 +60,7 @@
             "ru-RU": "Цветок"
         },
         "description": {
-            "en-GB": "Small flower shaped dinghies powered by a centrally-mounted motor controlled by the passengers",
+            "en-GB": "Small flower-shaped hovercraft vehicles powered by a centrally-mounted motor controlled by the passengers",
             "fr-FR": "Petits canots pneumatiques en forme de fleurs alimentés par un moteur central que contrôlent les passagers",
             "de-DE": "Kleine Schlauchboote in Blumenform, die durch einen in der Mitte angebrachten Motor betrieben und von den Fahrgästen gesteuert werden.",
             "es-ES": "Pequeños botes decorados como flores controlados por un monitor central que controlan los pasajeros.",

--- a/objects/rct2tt/ride/rct2.tt.flygboat.json
+++ b/objects/rct2tt/ride/rct2.tt.flygboat.json
@@ -72,7 +72,7 @@
     "images": ["$RCT2:OBJDATA/FLYGBOAT.DAT[0..1762]"],
     "strings": {
         "name": {
-            "en-GB": "Flying boats",
+            "en-GB": "Flying Boats",
             "fr-FR": "Bateau volant",
             "de-DE": "Fliegende Schiffe",
             "es-ES": "Viaje en el bote volante",

--- a/objects/rct2tt/ride/rct2.tt.ganstrcr.json
+++ b/objects/rct2tt/ride/rct2.tt.ganstrcr.json
@@ -108,7 +108,7 @@
             "ru-RU": "Горки гангстеров"
         },
         "description": {
-            "en-GB": "1920s Themed Gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+            "en-GB": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
             "fr-FR": "Train sur le thème des gangsters des années folles propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversions renversantes",
             "de-DE": "Die Gangster-Fluchtwagen aus den Zwanzigern werden aus der Station heraus mit Linearmotoren beschleunigt und rasen durch verdrehte Loopings.",
             "es-ES": "Los coches, ambientados como de gángsteres de los años veinte tienen que ser acelerados por motores de inducción lineal, para coger velocidad para los giros en inversión.",

--- a/objects/rct2tt/ride/rct2.tt.gintspdr.json
+++ b/objects/rct2tt/ride/rct2.tt.gintspdr.json
@@ -412,7 +412,7 @@
             "ru-RU": "Паук"
         },
         "description": {
-            "en-GB": "Riders ride in pairs of themed seats which rotate around a large B-Movie Spider.",
+            "en-GB": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
             "fr-FR": "Les passagers voyagent par deux à bord de sièges thématiques autour d'une araignée géante de film de série B.",
             "de-DE": "Die Fahrer sitzen zu zweit in thematisch gestalteten Sitzen, die sich um eine große B-Movie-Spinne drehen.",
             "es-ES": "Los usuarios van en parejas, en asientos decorados que giran en torno a una gran araña de películas de serie B.",

--- a/objects/rct2tt/ride/rct2.tt.hovercar.json
+++ b/objects/rct2tt/ride/rct2.tt.hovercar.json
@@ -84,7 +84,7 @@
             "ru-RU": "Ховеркары"
         },
         "description": {
-            "en-GB": "Mag Lev technology has been implemented to create the illusion of futuristic hover cars",
+            "en-GB": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
             "fr-FR": "La technologie de lévitation magnétique a été intégrée pour donner l'illusion de voitures futuristes sur coussins d'air",
             "de-DE": "Magnetschwebe-Technologie für die Illusion futuristischer Schwebewagen",
             "es-ES": "La tecnología de levitación magnética se ha implementado para crear la ilusión de aerodeslizadores futuristas.",

--- a/objects/rct2tt/ride/rct2.tt.jetplane.json
+++ b/objects/rct2tt/ride/rct2.tt.jetplane.json
@@ -90,7 +90,7 @@
             "ru-RU": "Горки-Самолет"
         },
         "description": {
-            "en-GB": "A compact roller coaster with individual cars and smooth twisting drops",
+            "en-GB": "Roller coaster cars in the shape of jet planes",
             "fr-FR": "Des voitures individuelles descendent des pentes régulières en virage",
             "de-DE": "Eine kompakte Achterbahn mit individuellen Wagen und sanften, gewundenen Abfahrten",
             "es-ES": "Una montaña rusa compacta con vagones individuales y suaves caídas en espiral.",

--- a/objects/rct2tt/ride/rct2.tt.jousting.json
+++ b/objects/rct2tt/ride/rct2.tt.jousting.json
@@ -56,7 +56,7 @@
             "ru-RU": "Рыцарские горки"
         },
         "description": {
-            "en-GB": "Riders sit on the back of Horse-shaped vehicles along a single-rail track",
+            "en-GB": "Riders sit on the back of horse-shaped vehicles along a single-rail track",
             "fr-FR": "Les passagers voyagent à bord de véhicules en forme de chevaux le long d'une voie monorail",
             "de-DE": "Die Fahrgäste sitzen auf dem Rücken von Pferde-artigen Wagen auf einer Einschienen-Strecke.",
             "es-ES": "Los pasajeros se montan en la grupa de vehículos en forma de caballos que van por una vía monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.microbus.json
+++ b/objects/rct2tt/ride/rct2.tt.microbus.json
@@ -139,7 +139,7 @@
             "ru-RU": "Микробус"
         },
         "description": {
-            "en-GB": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+            "en-GB": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
             "fr-FR": "Les spectateurs visionnent un film dans une nacelle simulant les mouvements grâce à un bras hydraulique",
             "de-DE": "Die Fahrer sehen in der Bewegungssimulations-Kapsel einen Film, während diese von einem hydraulischen Arm bewegt und gedreht wird.",
             "es-ES": "Los viajeros ven una película en el interior de un sistema de simulación mientras son movidos y girados por un brazo hidráulico.",

--- a/objects/rct2tt/ride/rct2.tt.neptunex.json
+++ b/objects/rct2tt/ride/rct2.tt.neptunex.json
@@ -412,7 +412,7 @@
             "ru-RU": "Нептун"
         },
         "description": {
-            "en-GB": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune.",
+            "en-GB": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
             "fr-FR": "Les passagers voyagent par deux à bord de sièges thématiques autour d'une statue animée de Neptune.",
             "de-DE": "Die Fahrgäste fahren zu zweit in Sitzen, die um eine animierte Neptunstatue rotieren.",
             "es-ES": "Los usuarios se montan por parejas, en asientos perfectamente ambientados que giran alrededor de una estatua de Neptuno.",

--- a/objects/rct2tt/ride/rct2.tt.oakbarel.json
+++ b/objects/rct2tt/ride/rct2.tt.oakbarel.json
@@ -74,7 +74,7 @@
             "ru-RU": "Дубовая Бочка"
         },
         "description": {
-            "en-GB": "Oak Barrels meander along a wide water channel, splashing through waterfalls and thrilling riders through foaming rapids",
+            "en-GB": "Oak barrels meander along a wide water channel, splashing through waterfalls and thrilling riders through foaming rapids",
             "fr-FR": "Des tonneaux serpentent le long d'un large cours d'eau, puis dévalent des rapides et des chutes d'eau spectaculaires",
             "de-DE": "Eichenfässer gleiten durch einen breiten Wasserkanal, zischen durch Wasserfälle und schäumende Stromschnellen.",
             "es-ES": "Los barriles de roble van a la deriva por un ancho canal de agua, cayendo por cataratas y pasando por estremecedores rápidos.",

--- a/objects/rct2tt/ride/rct2.tt.polchase.json
+++ b/objects/rct2tt/ride/rct2.tt.polchase.json
@@ -98,7 +98,7 @@
             "ru-RU": "Горки-Погоня"
         },
         "description": {
-            "en-GB": "A looping roller coaster where the riders ride in a sitting position",
+            "en-GB": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
             "fr-FR": "Grand huit que les passagers parcourent assis",
             "de-DE": "Eine Achterbahn mit Loopings, in der die Fahrer sitzend fahren",
             "es-ES": "Una montaña rusa llena de bucles en la que los viajeros van sentados",

--- a/objects/rct2tt/ride/rct2.tt.policecr.json
+++ b/objects/rct2tt/ride/rct2.tt.policecr.json
@@ -117,7 +117,7 @@
             "ru-RU": "Полиция"
         },
         "description": {
-            "en-GB": "1960s Themed Police cars run on wooden tracks, turning around on special reversing sections",
+            "en-GB": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
             "fr-FR": "Voitures de police des années 60 dévalant une voie en bois, tournant à des sections inverseuses spéciales",
             "de-DE": "Polizeiautos aus den 60ern fahren über eine Holzstrecke und drehen an speziellen Wendeabschnitten.",
             "es-ES": "Coches decorados como de la policía en los años sesenta que circulan por guías de madera, girando completamente en secciones de inversión especiales.",

--- a/objects/rct2tt/ride/rct2.tt.raptorxx.json
+++ b/objects/rct2tt/ride/rct2.tt.raptorxx.json
@@ -43,7 +43,7 @@
     "images": ["$RCT2:OBJDATA/RAPTORXX.DAT[0..258]"],
     "strings": {
         "name": {
-            "en-GB": "Raptor Racers Coaster",
+            "en-GB": "Racing Raptors",
             "fr-FR": "La course du raptor",
             "de-DE": "Raptor-Rennachterbahn",
             "es-ES": "Montaña rusa Raptor",
@@ -58,7 +58,7 @@
             "ru-RU": "Раптор Рейсерс"
         },
         "description": {
-            "en-GB": "Riders sit on the back of Raptor-shaped vehicles along a single-rail track",
+            "en-GB": "Riders sit on the back of raptor-shaped vehicles along a single-rail track",
             "fr-FR": "Les passagers voyagent à l'arrière de véhicules en forme de raptor sur une voie monorail",
             "de-DE": "Die Fahrgäste sitzen auf dem Rücken von Raptor-artigen Wagen auf einer Einschienen-Strecke.",
             "es-ES": "Los usuarios se sientan en vehículos con forma de velocirraptor, en un circuito monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.rivrstyx.json
+++ b/objects/rct2tt/ride/rct2.tt.rivrstyx.json
@@ -58,7 +58,7 @@
             "ru-RU": "Стикс"
         },
         "description": {
-            "en-GB": "Raft-shaped boats gently meander around a river track",
+            "en-GB": "Boats gently meander around a river track",
             "fr-FR": "Des bateaux en forme de radeau descendent paisiblement une voie navigable",
             "de-DE": "Wildwasserboote gleiten einen Flusslauf entlang.",
             "es-ES": "Botes con forma de balsa que serpentean tranquilamente por un circuito de río.",

--- a/objects/rct2tt/ride/rct2.tt.schoolbs.json
+++ b/objects/rct2tt/ride/rct2.tt.schoolbs.json
@@ -65,7 +65,7 @@
     "images": ["$RCT2:OBJDATA/SCHOOLBS.DAT[0..802]"],
     "strings": {
         "name": {
-            "en-GB": "School Bus Ride",
+            "en-GB": "School Bus Trams",
             "fr-FR": "Bus scolaire",
             "de-DE": "Schulbus-Fahrt",
             "es-ES": "Viaje del autocar escolar",
@@ -80,7 +80,7 @@
             "ru-RU": "Автобус"
         },
         "description": {
-            "en-GB": "Replica Yellow Bus themed trams",
+            "en-GB": "Miniature trams themed to look like school buses",
             "fr-FR": "Tramways reprenant la thématique des bus scolaires jaunes américains",
             "de-DE": "Bahnen als Nachbauten von gelben Schulbussen",
             "es-ES": "Réplica del clásico autocar amarillo",

--- a/objects/rct2tt/ride/rct2.tt.stamphrd.json
+++ b/objects/rct2tt/ride/rct2.tt.stamphrd.json
@@ -116,7 +116,7 @@
             "ru-RU": "Стадные горки"
         },
         "description": {
-            "en-GB": "A looping roller coaster with vehicles in the shape of a stampeding dinosaur herd.",
+            "en-GB": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
             "fr-FR": "Grand huit où les véhicules représentent un troupeau de dinosaures en fuite.",
             "de-DE": "Eine Achterbahn mit Loopings in Form einer flüchtenden Dinosaurierherde.",
             "es-ES": "Una montaña rusa llena de bucles, con vehículos en forma de rebaños de dinosaurios en estampida.",

--- a/objects/rct2tt/ride/rct2.tt.tommygun.json
+++ b/objects/rct2tt/ride/rct2.tt.tommygun.json
@@ -412,7 +412,7 @@
             "ru-RU": "Томми-Ган"
         },
         "description": {
-            "en-GB": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun.",
+            "en-GB": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
             "fr-FR": "Les passagers voyagent par deux à bord de sièges thématiques autour d'une mitraillette géante.",
             "de-DE": "Die Fahrer sitzen zu zweit in Sitzen, die sich um die Nachbildung einer großen Maschinenpistole drehen.",
             "es-ES": "Los usuarios van en parejas, en vagones decorados que giran alrededor de una réplica de una metralleta.",

--- a/objects/rct2tt/ride/rct2.tt.trebucht.json
+++ b/objects/rct2tt/ride/rct2.tt.trebucht.json
@@ -135,7 +135,7 @@
             "ru-RU": "Катапульта"
         },
         "description": {
-            "en-GB": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age Siege Weapon",
+            "en-GB": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
             "fr-FR": "Chariot suspendu à deux grands bras, inspiré d'une arme médiévale",
             "de-DE": "Die Fahrgäste fahren in einem Waggon, der von zwei langen Armen gehalten wird, basierend auf einer Belagerungswaffe aus dem finsteren Mittelalter.",
             "es-ES": "Los pasajeros viajan suspendidos en dos grandes brazos, basados en el arma de asedio medieval.",

--- a/objects/rct2tt/ride/rct2.tt.tricatop.json
+++ b/objects/rct2tt/ride/rct2.tt.tricatop.json
@@ -46,7 +46,7 @@
     "images": ["$RCT2:OBJDATA/TRICATOP.DAT[0..130]"],
     "strings": {
         "name": {
-            "en-GB": "Triceratops Dodgem Cars",
+            "en-GB": "Triceratops Dodgems",
             "fr-FR": "Auto-tamponneuses tricératops",
             "de-DE": "Triceratops-Autoskooter-Wagen",
             "es-ES": "Coches de choque Triceratops",
@@ -61,7 +61,7 @@
             "ru-RU": "Трицерапторы"
         },
         "description": {
-            "en-GB": "Riders lock horns with each other in Triceratops dodgem cars",
+            "en-GB": "Riders lock horns with each other in triceratops dodgem cars",
             "fr-FR": "Les passagers se rentrent dedans à bord d'auto-tamponneuses en forme de tricératops",
             "de-DE": "Die Fahrer liefern sich beim Autoskooter harte Gefechte in Triceratops-Wagen.",
             "es-ES": "Los usuarios se pegan cornadas en los coches de choque Triceratops.",

--- a/objects/rct2ww/ride/rct2.ww.bullet.json
+++ b/objects/rct2ww/ride/rct2.ww.bullet.json
@@ -106,7 +106,7 @@
     "images": ["$RCT2:OBJDATA/BULLET.DAT[0..4470]"],
     "strings": {
         "name": {
-            "en-GB": "Bullet Coaster",
+            "en-GB": "Bullet Trains",
             "fr-FR": "Montagnes Shinkansen",
             "de-DE": "Bullet-Achterbahn",
             "es-ES": "Montaña Bala",
@@ -121,7 +121,7 @@
             "pt-BR": "Montanha Bala"
         },
         "description": {
-            "en-GB": "Roller coaster with Japanese Bullet Train themed cars",
+            "en-GB": "Japanese Bullet Train themed roller coaster cars",
             "fr-FR": "Montagnes russes avec voitures en forme de TGV japonais",
             "de-DE": "Eine Achterbahn im Stil japanischer Schnellzüge (sogenannter Bullet Trains)",
             "es-ES": "Montaña rusa con vagones inspirados en el tren bala japonés",

--- a/objects/rct2ww/ride/rct2.ww.caddilac.json
+++ b/objects/rct2ww/ride/rct2.ww.caddilac.json
@@ -106,7 +106,7 @@
     "images": ["$RCT2:OBJDATA/CADDILAC.DAT[0..4470]"],
     "strings": {
         "name": {
-            "en-GB": "Limousine Rollercoaster",
+            "en-GB": "Limousine Trains",
             "fr-FR": "Limousines",
             "de-DE": "Limousinen-Achterbahn",
             "es-ES": "Montaña Rusa de Limusina",
@@ -121,7 +121,7 @@
             "pt-BR": "Montanha-russa Limusine"
         },
         "description": {
-            "en-GB": "Roller coaster with Limousine themed cars",
+            "en-GB": "Limousine themed roller coaster cars",
             "fr-FR": "Montagnes russes avec voitures en forme de limousine",
             "de-DE": "Achterbahn mit Wagen im Limousinenstil",
             "es-ES": "Montaña rusa con vagones inspirados en las limusinas",

--- a/objects/rct2ww/ride/rct2.ww.coffeecu.json
+++ b/objects/rct2ww/ride/rct2.ww.coffeecu.json
@@ -413,7 +413,7 @@
             "pt-BR": "Xícaras Giratórias"
         },
         "description": {
-            "en-GB": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+            "en-GB": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
             "fr-FR": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
             "de-DE": "Die Fahrgäste nehmen auf rotierenden Sitzpaaren Platz, die sich an den Enden dreier langer kreisender Arme befinden",
             "es-ES": "Los pasajeros montan en parejas de dos asientos que giran alrededor de los extremos de tres largos brazos rotatorios",

--- a/objects/rct2ww/ride/rct2.ww.condorrd.json
+++ b/objects/rct2ww/ride/rct2.ww.condorrd.json
@@ -103,7 +103,7 @@
             "zh-TW": "神鷹暢遊"
         },
         "description": {
-            "en-GB": "Riding in special harnesses below the track, riders experience the feeling of flight as they swoop through the air in Condor-shaped trains",
+            "en-GB": "Riding in special harnesses below the track, riders experience the feeling of flight as they swoop through the air in condor-shaped trains",
             "fr-FR": "Les passagers sont couchés à plat ventre dans une voiture en forme de condor se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
             "de-DE": "Die Passagiere fahren, in speziellen Gurten hängend, unterhalb der Strecke. In den kondorförmigen Wagen erleben sie dabei ein Gefühl des Fliegens.",
             "es-ES": "Los pasajeros viajan boca abajo y acostados, suspendidos del arnés debajo de la pista en un vagón con forma de Cóndor que se balancea libremente de un lado a otro al pasar por las curvas.",

--- a/objects/rct2ww/ride/rct2.ww.congaeel.json
+++ b/objects/rct2ww/ride/rct2.ww.congaeel.json
@@ -121,7 +121,7 @@
             "ru-RU": "Угрь-Конга"
         },
         "description": {
-            "en-GB": "Trains with shoulder restraints, in the shape of a Conger Eel.",
+            "en-GB": "Trains with shoulder restraints, in the shape of conger eels",
             "fr-FR": "Montagnes russes compactes et métalliques sur lesquelles le train en forme d'anguille effectue tire-bouchons et boucles",
             "de-DE": "Eine kompakte Stahlachterbahn, bei der ein aalförmiger Zug durch Schrauben und Schleifen fährt",
             "es-ES": "Una montaña rusa compacta de acero, donde un tren con forma de anguila circula por rizos y sacacorchos",

--- a/objects/rct2ww/ride/rct2.ww.crnvbfly.json
+++ b/objects/rct2ww/ride/rct2.ww.crnvbfly.json
@@ -60,7 +60,7 @@
     "images": ["$RCT2:OBJDATA/CRNVBFLY.DAT[0..242]"],
     "strings": {
         "name": {
-            "en-GB": "Carnival Float Ride - Butterfly Cars",
+            "en-GB": "Carnival Butterfly Cars",
             "fr-FR": "Carnaval - Voitures papillons",
             "de-DE": "Karnevalswagenbahn - Schmetterlingswagen",
             "es-ES": "Atracción flotadores de carnaval; vagones mariposa",
@@ -74,7 +74,7 @@
             "pt-BR": "Carros Borboleta do Carnaval"
         },
         "description": {
-            "en-GB": "Roller coaster cars in the shape of butterfly carnival floats",
+            "en-GB": "Cars in the shape of butterfly carnival floats",
             "fr-FR": "Voitures de montagnes russes en forme de chars papillons de carnaval",
             "de-DE": "Achterbahnwagen mit dem Aussehen von Schmetterlings-Karnevalswagen",
             "es-ES": "Coches de montaña rusa con forma de flotadores mariposa de carnaval",

--- a/objects/rct2ww/ride/rct2.ww.crnvfrog.json
+++ b/objects/rct2ww/ride/rct2.ww.crnvfrog.json
@@ -60,7 +60,7 @@
     "images": ["$RCT2:OBJDATA/CRNVFROG.DAT[0..242]"],
     "strings": {
         "name": {
-            "en-GB": "Carnival Float Ride - Frog Cars",
+            "en-GB": "Carnival Frog Cars",
             "fr-FR": "Carnaval - Voitures grenouilles",
             "de-DE": "Karnevalswagenbahn - Froschwagen",
             "es-ES": "Atracción flotadores de carnaval; vagones rana",
@@ -74,7 +74,7 @@
             "pt-BR": "Carros Sapo do Carnaval"
         },
         "description": {
-            "en-GB": "Roller coaster cars in the shape of frog carnival floats",
+            "en-GB": "Cars in the shape of frog carnival floats",
             "fr-FR": "Voitures de montagnes russes en forme de chars grenouilles de carnaval",
             "de-DE": "Achterbahnwagen mit dem Aussehen von Frosch-Karnevalswagen",
             "es-ES": "Vagones de montaña rusa con forma de flotadores rana de carnaval",

--- a/objects/rct2ww/ride/rct2.ww.crnvlzrd.json
+++ b/objects/rct2ww/ride/rct2.ww.crnvlzrd.json
@@ -60,7 +60,7 @@
     "images": ["$RCT2:OBJDATA/CRNVLZRD.DAT[0..242]"],
     "strings": {
         "name": {
-            "en-GB": "Carnival Float Ride - Lizard Cars",
+            "en-GB": "Carnival Lizard Cars",
             "fr-FR": "Carnaval - Voitures lézards",
             "de-DE": "Karnevalswagenbahn - Echsenwagen",
             "es-ES": "Atracción flotadores de carnaval; vagones lagarto",
@@ -74,7 +74,7 @@
             "pt-BR": "Carros Lagarto do Carnaval"
         },
         "description": {
-            "en-GB": "Roller coaster cars in the shape of lizard carnival floats",
+            "en-GB": "Cars in the shape of lizard carnival floats",
             "fr-FR": "Voitures de montagnes russes en forme de chars lézards de carnaval",
             "de-DE": "Achterbahnwagen mit dem Aussehen von Echsen-Karnevalswagens",
             "es-ES": "Vagones de montaña rusa con forma de flotadores lagarto de carnaval",

--- a/objects/rct2ww/ride/rct2.ww.crocflum.json
+++ b/objects/rct2ww/ride/rct2.ww.crocflum.json
@@ -64,7 +64,7 @@
     "images": ["$RCT2:OBJDATA/CROCFLUM.DAT[0..626]"],
     "strings": {
         "name": {
-            "en-GB": "Crocodile boats",
+            "en-GB": "Crocodile Boats",
             "fr-FR": "Crocodile",
             "de-DE": "Krokodilsboote",
             "es-ES": "Atracción Cocodrilo",

--- a/objects/rct2ww/ride/rct2.ww.dhowwatr.json
+++ b/objects/rct2ww/ride/rct2.ww.dhowwatr.json
@@ -40,7 +40,7 @@
     "images": ["$RCT2:OBJDATA/DHOWWATR.DAT[0..114]"],
     "strings": {
         "name": {
-            "en-GB": "Dhow boats",
+            "en-GB": "Dhow Boats",
             "fr-FR": "Ballade en sampan",
             "de-DE": "Dhau-Boote",
             "es-ES": "Atracción acuática Dhow",

--- a/objects/rct2ww/ride/rct2.ww.diamondr.json
+++ b/objects/rct2ww/ride/rct2.ww.diamondr.json
@@ -412,7 +412,7 @@
             "pt-BR": "Diamante"
         },
         "description": {
-            "en-GB": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+            "en-GB": "Riders ride in pairs of themed seats rotating around a large diamond",
             "fr-FR": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
             "de-DE": "Die Fahrgäste nehmen auf rotierenden Sitzpaaren Platz, die sich an den Enden dreier langer kreisender Arme befinden",
             "es-ES": "Los pasajeros montan en parejas de dos asientos que giran alrededor de los extremos de tres largos brazos rotatorios",

--- a/objects/rct2ww/ride/rct2.ww.dolphinr.json
+++ b/objects/rct2ww/ride/rct2.ww.dolphinr.json
@@ -48,7 +48,7 @@
     "images": ["$RCT2:OBJDATA/DOLPHINR.DAT[0..66]"],
     "strings": {
         "name": {
-            "en-GB": "Dolphin boats",
+            "en-GB": "Dolphin Boats",
             "fr-FR": "Dauphin",
             "de-DE": "Delfinboote",
             "es-ES": "Atracción Delfín",
@@ -64,7 +64,7 @@
             "ru-RU": "Дельфин"
         },
         "description": {
-            "en-GB": "Single-seater Dolphin-shaped vehicles which riders can drive themselves",
+            "en-GB": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
             "fr-FR": "Véhicules individuels en forme de dauphins que les visiteurs peuvent conduire eux-mêmes",
             "de-DE": "Einsitzige delfinförmige Fahrzeuge, die die Passagiere selbst steuern können",
             "es-ES": "Vehículos de uno solo asiento con forma de delfín que son conducidos por el propio pasajero",

--- a/objects/rct2ww/ride/rct2.ww.dragon.json
+++ b/objects/rct2ww/ride/rct2.ww.dragon.json
@@ -106,7 +106,7 @@
     "images": ["$RCT2:OBJDATA/DRAGON.DAT[0..4470]"],
     "strings": {
         "name": {
-            "en-GB": "Dragon Coaster",
+            "en-GB": "Dragon Trains",
             "fr-FR": "Montagnes du dragon",
             "de-DE": "Drachen-Achterbahn",
             "es-ES": "Montaña del Dragón",
@@ -121,7 +121,7 @@
             "pt-BR": "Montanha do Dragão"
         },
         "description": {
-            "en-GB": "Roller coaster with dragon-themed cars",
+            "en-GB": "Dragon-themed roller coaster cars",
             "fr-FR": "Montagnes russes avec voitures en forme de dragon",
             "de-DE": "Eine Achterbahn mit Wagen im Drachen-Stil",
             "es-ES": "Montaña rusa con vagones inspirados en dragones",

--- a/objects/rct2ww/ride/rct2.ww.faberge.json
+++ b/objects/rct2ww/ride/rct2.ww.faberge.json
@@ -397,7 +397,7 @@
     "images": ["$RCT2:OBJDATA/FABERGE.DAT[0..242]"],
     "strings": {
         "name": {
-            "en-GB": "Faberge Egg Ride",
+            "en-GB": "Fabergé Egg Ride",
             "fr-FR": "Œufs de Fabergé",
             "de-DE": "Fabergé-Eierbahn",
             "es-ES": "Atracción Huevo Faberge",
@@ -412,7 +412,7 @@
             "pt-BR": "Ovo Fabergé"
         },
         "description": {
-            "en-GB": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+            "en-GB": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
             "fr-FR": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
             "de-DE": "Die Fahrgäste nehmen auf rotierenden Sitzpaaren Platz, die sich an den Enden dreier langer kreisender Arme befinden",
             "es-ES": "Los pasajeros viajan en parejas de asientos que rotan alrededor de los extremos de tres largos brazos giratorios",

--- a/objects/rct2ww/ride/rct2.ww.gratwhte.json
+++ b/objects/rct2ww/ride/rct2.ww.gratwhte.json
@@ -123,7 +123,7 @@
             "ru-RU": "Белая акула"
         },
         "description": {
-            "en-GB": "Trains with shoulder restraints, in the shape of a Great White Shark",
+            "en-GB": "Trains with shoulder restraints, in the shape of a great white shark",
             "fr-FR": "Train spacieux disposant d'une simple barre de protection au niveau des jambes",
             "de-DE": "Geräumige Züge mit einfachen Beckenhalterungen",
             "es-ES": "Trenes espaciosos con simples barras de sujeción",

--- a/objects/rct2ww/ride/rct2.ww.italypor.json
+++ b/objects/rct2ww/ride/rct2.ww.italypor.json
@@ -413,7 +413,7 @@
             "pt-BR": "Polícia Italiana"
         },
         "description": {
-            "en-GB": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+            "en-GB": "Riders ride in pairs in Italian police car replicas and rotate in circles",
             "fr-FR": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
             "de-DE": "Die Fahrgäste nehmen auf rotierenden Sitzpaaren Platz, die sich an den Enden dreier langer kreisender Arme befinden",
             "es-ES": "Los pasajeros viajan en parejas de asientos que rotan alrededor de los extremos de tres largos brazos giratorios",

--- a/objects/rct2ww/ride/rct2.ww.jaguarrd.json
+++ b/objects/rct2ww/ride/rct2.ww.jaguarrd.json
@@ -75,7 +75,7 @@
     "images": ["$RCT2:OBJDATA/JAGUARRD.DAT[0..1814]"],
     "strings": {
         "name": {
-            "en-GB": "Jaguar Ride",
+            "en-GB": "Jaguar Cars",
             "fr-FR": "Jaguar",
             "de-DE": "Jaguarbahn",
             "es-ES": "Atracción Jaguar",
@@ -90,7 +90,7 @@
             "pt-BR": "Jaguar"
         },
         "description": {
-            "en-GB": "Roller coaster cars themed to look like a jaguar.",
+            "en-GB": "Roller coaster cars themed to look like jaguars",
             "fr-FR": "Voitures de montagnes russes en forme de jaguar.",
             "de-DE": "Achterbahnwagen, die aussehen wie Jaguare.",
             "es-ES": "Montaña rusa con vagones en forma de jaguares",

--- a/objects/rct2ww/ride/rct2.ww.kolaride.json
+++ b/objects/rct2ww/ride/rct2.ww.kolaride.json
@@ -46,7 +46,7 @@
     "images": ["$RCT2:OBJDATA/KOLARIDE.DAT[0..1562]"],
     "strings": {
         "name": {
-            "en-GB": "Koala car",
+            "en-GB": "Koala Car",
             "fr-FR": "Koala",
             "de-DE": "Koalawagen",
             "es-ES": "Atracción Koala",
@@ -61,7 +61,7 @@
             "ru-RU": "Коала Райд"
         },
         "description": {
-            "en-GB": "Large coaster car for the Reverse Freefall Coaster",
+            "en-GB": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
             "fr-FR": "Voiture destinée à la Chute libre renversée",
             "de-DE": "Großer Wagen für die umgekehrte Freefall-Bahn",
             "es-ES": "Gran vagón para la montaña rusa invertida de caída libre",

--- a/objects/rct2ww/ride/rct2.ww.lionride.json
+++ b/objects/rct2ww/ride/rct2.ww.lionride.json
@@ -90,7 +90,7 @@
             "ru-RU": "Лев"
         },
         "description": {
-            "en-GB": "Roller coaster cars themed to look like a lion.",
+            "en-GB": "Roller coaster cars themed to look like lions",
             "fr-FR": "Voitures de montagnes russes en forme de lion.",
             "de-DE": "Achterbahnwagen, die aussehen wie Löwe.",
             "es-ES": "Montaña rusa con vagones en forma de leónes",

--- a/objects/rct2ww/ride/rct2.ww.londonbs.json
+++ b/objects/rct2ww/ride/rct2.ww.londonbs.json
@@ -65,7 +65,7 @@
     "images": ["$RCT2:OBJDATA/LONDONBS.DAT[0..802]"],
     "strings": {
         "name": {
-            "en-GB": "Routemaster buses",
+            "en-GB": "Routemaster Buses",
             "fr-FR": "Tram bus londonien",
             "de-DE": "Londoner Busse",
             "es-ES": "Tranvía de autobús londinense",

--- a/objects/rct2ww/ride/rct2.ww.mandarin.json
+++ b/objects/rct2ww/ride/rct2.ww.mandarin.json
@@ -65,7 +65,7 @@
             "ru-RU": "Мандариновая утка"
         },
         "description": {
-            "en-GB": "Duck shaped boat, propelled by the pedalling front seat passengers",
+            "en-GB": "Duck-shaped boat, propelled by the pedalling front seat passengers",
             "fr-FR": "Bateau en forme de cygne, propulsé par les passagers avant à l'aide d'un pédalier",
             "de-DE": "Ein schwanenförmiges Boot, das von den Fahrgästen auf den Vordersitzen angetrieben wird, die selber in die Pedale treten müssen",
             "es-ES": "Bote con forma de cisne, impulsado por el pedaleo de los pasajeros del asiento delantero",

--- a/objects/rct2ww/ride/rct2.ww.mantaray.json
+++ b/objects/rct2ww/ride/rct2.ww.mantaray.json
@@ -70,7 +70,7 @@
     "images": ["$RCT2:OBJDATA/MANTARAY.DAT[0..1762]"],
     "strings": {
         "name": {
-            "en-GB": "Manta Ray boats",
+            "en-GB": "Manta Ray Boats",
             "fr-FR": "Raie manta",
             "de-DE": "Mantarochenboote",
             "es-ES": "Atracción Manta Raya",
@@ -85,7 +85,7 @@
             "ru-RU": "Манта Рей"
         },
         "description": {
-            "en-GB": "Coaster boats in the shape of a Manta Ray",
+            "en-GB": "Coaster boats in the shape of a manta ray",
             "fr-FR": "Grand bateau qui serpente le long d'une large voie navigable, monte sur des pentes grâce à un tapis roulant, et descend à toute vitesse de l'autre côté, éclaboussant allègrement les passagers",
             "de-DE": "Große Boote bewegen sich in einem breiten Wasserkanal, werden von einem Fließband über Hügel hinweg befördert und sausen steile Gefälle hinunter, damit die Fahrgäste von einem gigantischen Platscher durchnässt werden",
             "es-ES": "Botes de gran capacidad que viajan por un amplio canal de agua y son empujados hacia arriba por una cinta transportadora, para luego precipitarse cuesta abajo empapando a los viajeros con una salpicadura gigante",

--- a/objects/rct2ww/ride/rct2.ww.ostrich.json
+++ b/objects/rct2ww/ride/rct2.ww.ostrich.json
@@ -118,7 +118,7 @@
             "ru-RU": "Австрийцы"
         },
         "description": {
-            "en-GB": "A looping roller coaster where the riders ride in a standing position",
+            "en-GB": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
             "fr-FR": "Montagnes russes à loopings où les passagers sont debout",
             "de-DE": "Eine Looping-Achterbahn, in der die Fahrgäste stehen",
             "es-ES": "Una montaña rusa con rizos en la que los pasajeros viajan de pie",

--- a/objects/rct2ww/ride/rct2.ww.outriggr.json
+++ b/objects/rct2ww/ride/rct2.ww.outriggr.json
@@ -41,7 +41,7 @@
     "images": ["$RCT2:OBJDATA/OUTRIGGR.DAT[0..114]"],
     "strings": {
         "name": {
-            "en-GB": "Outrigger canoes",
+            "en-GB": "Outrigger Canoes",
             "fr-FR": "Outrigger",
             "de-DE": "Auslegerkanus",
             "es-ES": "Atracción de Canoa",

--- a/objects/rct2ww/ride/rct2.ww.rhinorid.json
+++ b/objects/rct2ww/ride/rct2.ww.rhinorid.json
@@ -68,7 +68,7 @@
             "ru-RU": "Носорог"
         },
         "description": {
-            "en-GB": "A compact steel-tracked roller coaster with a spiral lift hill and cars with in-line seating",
+            "en-GB": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
             "fr-FR": "Montagnes russes compactes et métalliques avec une remontée en spirale et des voitures disposant de sièges en ligne",
             "de-DE": "Eine kompakte Stahlachterbahn mit einem Spirallifthügel und Wagen mit Sitzen in einer Reihe",
             "es-ES": "Una montaña rusa compacta de acero con una colina de subida en espiral y vagones con asientos en línea",

--- a/objects/rct2ww/ride/rct2.ww.seals.json
+++ b/objects/rct2ww/ride/rct2.ww.seals.json
@@ -104,7 +104,7 @@
     "images": ["$RCT2:OBJDATA/SEALS.DAT[0..4470]"],
     "strings": {
         "name": {
-            "en-GB": "Seals Rollercoaster",
+            "en-GB": "Seal Trains",
             "fr-FR": "Montagnes des phoques",
             "de-DE": "Robben-Achterbahn",
             "es-ES": "Montaña Rusa Focas",
@@ -119,7 +119,7 @@
             "pt-BR": "Montanha-Russa de Foca"
         },
         "description": {
-            "en-GB": "A compact steel-tracked roller coaster where the train travels through corkscrews and loops",
+            "en-GB": "Roller coaster trains with shoulder restraints themed to look like seals",
             "fr-FR": "Montagnes russes compactes et métalliques dont le train effectue tire-bouchons et boucles",
             "de-DE": "Eine kompakte Stahlschienen-Achterbahn, auf welcher der Zug Korkenzieher und Loopings fährt",
             "es-ES": "Una montaña rusa compacta de acero donde los vagones circulan por rizos y sacacorchos",

--- a/objects/rct2ww/ride/rct2.ww.sloth.json
+++ b/objects/rct2ww/ride/rct2.ww.sloth.json
@@ -48,7 +48,7 @@
     "images": ["$RCT2:OBJDATA/SLOTH.DAT[0..4622]"],
     "strings": {
         "name": {
-            "en-GB": "Sloth Ride",
+            "en-GB": "Sloth Trains",
             "fr-FR": "Paresseux",
             "de-DE": "Faultierbahn",
             "es-ES": "Atracción Perezoso",
@@ -63,7 +63,7 @@
             "pt-BR": "Preguiça"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of Sloth-shaped cars able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
             "fr-FR": "Train de montagnes russes suspendu constitué de voitures en forme de paresseux qui se balancent librement dans les virages",
             "de-DE": "Hängender Achterbahnzug mit Wagen, die Faultieren nachempfunden sind und in Kurven frei schwingen können",
             "es-ES": "Tren suspendido consistente en vagones con forma de perezoso que se balancean libremente al tomar las curvas",

--- a/objects/rct2ww/ride/rct2.ww.steamtrn.json
+++ b/objects/rct2ww/ride/rct2.ww.steamtrn.json
@@ -98,7 +98,7 @@
     "images": ["$RCT2:OBJDATA/STEAMTRN.DAT[0..1154]"],
     "strings": {
         "name": {
-            "en-GB": "Maharaja Steam Train",
+            "en-GB": "Maharaja Steam Trains",
             "fr-FR": "Train à vapeur",
             "de-DE": "Maharadscha-Dampfzug",
             "es-ES": "Tren de vapor",

--- a/objects/rct2ww/ride/rct2.ww.stgccstr.json
+++ b/objects/rct2ww/ride/rct2.ww.stgccstr.json
@@ -52,7 +52,7 @@
     "images": ["$RCT2:OBJDATA/STGCCSTR.DAT[0..2162]"],
     "strings": {
         "name": {
-            "en-GB": "Stage Coach Rollercoaster",
+            "en-GB": "Stage Coaches",
             "fr-FR": "Diligence",
             "de-DE": "Postkutschen-Achterbahn",
             "es-ES": "Montaña Rusa de Carroza",
@@ -67,7 +67,7 @@
             "pt-BR": "Diligência"
         },
         "description": {
-            "en-GB": "Wooden roller coaster trains with padded seats and lap bar restraints",
+            "en-GB": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
             "fr-FR": "Train pour montagnes russes en bois avec des sièges rembourrés et des barres de protection au niveau des jambes",
             "de-DE": "Holzachterbahnzüge mit gepolsterten Sitzen und Beckenhalterungen",
             "es-ES": "Trenes de madera con asientos acolchados y barras de sujeción",

--- a/objects/rct2ww/ride/rct2.ww.taxicstr.json
+++ b/objects/rct2ww/ride/rct2.ww.taxicstr.json
@@ -116,7 +116,7 @@
             "pt-BR": "Trens Taxi Amarelo"
         },
         "description": {
-            "en-GB": "A giant steel roller coaster capable of smooth drops and hills of over 300ft",
+            "en-GB": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
             "fr-FR": "Montagnes russes géantes proposant des chutes régulières depuis des collines dépassant les 100 mètres d'altitude",
             "de-DE": "Eine gigantische Stahlachterbahn mit gemäßigten Gefällen und Anstiegen von über 90 Metern",
             "es-ES": "Una montaña rusa gigante capaz de caídas suaves y subidas de más de 300 pies",

--- a/objects/rct2ww/ride/rct2.ww.tgvtrain.json
+++ b/objects/rct2ww/ride/rct2.ww.tgvtrain.json
@@ -135,7 +135,7 @@
             "ru-RU": "Поезд TGV"
         },
         "description": {
-            "en-GB": "Roller coaster trains are accelerated out of the station by linear induction motors to speed through twisting inversions",
+            "en-GB": "Roller coaster trains in the style of French high-speed trains (TGV) are accelerated out of the station by linear induction motors to speed through twisting inversions",
             "fr-FR": "Train de montagnes russes propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversions renversantes",
             "de-DE": "Achterbahnzüge werden mithilfe von Linearmotoren aus der Station heraus beschleunigt und rasen durch gewundene Überkopfteile",
             "es-ES": "Los trenes de la montaña rusa salen de la estación acelerados por unos motores de inducción para pasar a toda velocidad por unas retorcidas inversiones",

--- a/objects/rct2ww/ride/rct2.ww.tigrtwst.json
+++ b/objects/rct2ww/ride/rct2.ww.tigrtwst.json
@@ -89,7 +89,7 @@
             "ru-RU": "Бенгальский тигр"
         },
         "description": {
-            "en-GB": "Roller coaster cars capable of heartline twists",
+            "en-GB": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
             "fr-FR": "Montagnes russes avec inversions à 360°",
             "de-DE": "Achterbahnwagen, die sich um ihre Mittelachse drehen können",
             "es-ES": "Vagones capaces de dar giros a media altura",

--- a/objects/rct2ww/ride/rct2.ww.tutlboat.json
+++ b/objects/rct2ww/ride/rct2.ww.tutlboat.json
@@ -48,7 +48,7 @@
     "images": ["$RCT2:OBJDATA/TUTLBOAT.DAT[0..66]"],
     "strings": {
         "name": {
-            "en-GB": "Turtle boats",
+            "en-GB": "Turtle Boats",
             "fr-FR": "Tortue aquatique",
             "de-DE": "Schildkrötenboote",
             "es-ES": "Atracción acuática Tortuga",

--- a/objects/rct2ww/ride/rct2.ww.whicgrub.json
+++ b/objects/rct2ww/ride/rct2.ww.whicgrub.json
@@ -112,7 +112,7 @@
             "ru-RU": "Колдовство"
         },
         "description": {
-            "en-GB": "Roller coaster trains with small Grub-shaped cars",
+            "en-GB": "Roller coaster trains with small grub-shaped cars",
             "fr-FR": "Trains de montagnes russes avec voitures en forme d'asticots",
             "de-DE": "Achterbahnwagen mit dem Aussehen von Maden",
             "es-ES": "Trenes formados por pequeños vagones con forma de gorgojo",


### PR DESCRIPTION
Fixes #50.

Vehicles are renamed according to some rules:

* Vehicles must have a name that describes the vehicle itself rather than the ride/rollercoaster as a whole
* Exception: Dodgems, Flying Saucers and all their variants introduced in WW/TT. The term “Dodgems” instead of “Dodgem Cars” is used because all variants appear as unique ride in the ride list, using the vehicle name as the ride name
* Use plural form unless the ride can only have 1 vehicle
* Consistent capitalization
* Problems reported in #50 are fixed

Affects only `en-GB`.