### PR TITLE
Translate “Football Trains” to “Soccer Ball Trains” in en-US

### DIFF
--- a/objects/rct2ww/ride/rct2.ww.football.json
+++ b/objects/rct2ww/ride/rct2.ww.football.json
@@ -49,6 +49,7 @@
     "strings": {
         "name": {
             "en-GB": "Football Trains",
+            "en-US": "Soccer Ball Trains",
             "fr-FR": "Coupe du monde",
             "de-DE": "Fußballzüge",
             "es-ES": "Atracción Fútbol",
@@ -66,6 +67,7 @@
         },
         "description": {
             "en-GB": "Suspended roller coaster train consisting of football-shaped cars able to swing freely as the train goes around corners",
+            "en-US": "Suspended roller coaster train consisting of soccer ball-shaped cars able to swing freely as the train goes around corners",
             "fr-FR": "Train de montagnes russes suspendu constitué de voitures en forme de ballon de football qui se balancent librement dans les virages",
             "de-DE": "Hängender Achterbahnzug mit Wagen, die Fußbällen nachempfunden sind und in Kurven frei schwingen können",
             "es-ES": "Tren suspendido consistente en vagones con forma de balón de fútbol, los cuales se balancean libremente al tomar las curvas",


### PR DESCRIPTION
This PR translates the Football Trains vehicle to “Soccer Ball Trains” in en-US.