### PR TITLE
Simplify most vehicle descriptions

### DIFF
--- a/objects/rct2/ride/rct2.amt1.json
+++ b/objects/rct2/ride/rct2.amt1.json
@@ -90,7 +90,7 @@
             "ru-RU": "Шахтёрские горки"
         },
         "description": {
-            "en-GB": "Mine train themed roller coaster trains career along steel roller coaster track made to look like old railway track",
+            "en-GB": "Mine train-themed roller coaster trains",
             "fr-FR": "Trains emmenant les passagers sur des montagnes russes  dont les voies rappellent les vieilles voies ferrées",
             "de-DE": "Minenachterbahnzüge fahren auf Stahlschienen, die so aussehen wie alte Zugschienen",
             "es-ES": "El tren de la mina corre por una vía de acero que recuerda las viejas vías del tren",

--- a/objects/rct2/ride/rct2.arrsw1.json
+++ b/objects/rct2/ride/rct2.arrsw1.json
@@ -66,7 +66,7 @@
             "ru-RU": "Подвесные вагоны"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of cars able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
             "fr-FR": "Train suspendu à des montagnes russes et dont les voitures se balancent dans les virages",
             "de-DE": "Hängender Achterbahnzug, der aus Wagen besteht, die frei schwingen können, wenn der Zug um die Kurven fährt",
             "es-ES": "Vagones suspendidos que se balancean libremente al tomar las curvas",

--- a/objects/rct2/ride/rct2.arrsw2.json
+++ b/objects/rct2/ride/rct2.arrsw2.json
@@ -76,8 +76,8 @@
             "ru-RU": "Аэропланы"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of aeroplane shaped cars able to swing freely as the train goes around corners",
-            "en-US": "Suspended roller coaster train consisting of airplane shaped cars able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+            "en-US": "Suspended roller coaster trains consisting of airplane-shaped cars able to swing freely as the train goes around corners",
             "fr-FR": "Train suspendu à des montagnes russes et composé de voitures en forme d'avion qui se balancent librement dans les virages",
             "de-DE": "Ein hängender Achterbahnzug, der aus flugzeugförmigen Wagen besteht, die in Kurven frei schwingen",
             "es-ES": "Montaña rusa que consiste en vagones con forma de avión que giran libremente en las curvas",

--- a/objects/rct2/ride/rct2.arrt1.json
+++ b/objects/rct2/ride/rct2.arrt1.json
@@ -125,7 +125,7 @@
             "ru-RU": "Штопорные горки"
         },
         "description": {
-            "en-GB": "Roller coaster train with shoulder restraints",
+            "en-GB": "Roller coaster trains with shoulder restraints",
             "fr-FR": "Montagnes russes compactes dont les voies en acier prennent la forme de tire-bouchons et de boucles",
             "de-DE": "Eine kompakte Stahlachterbahn, bei der der Zug durch Schrauben und Schleifen fährt",
             "es-ES": "Una montaña rusa compacta de acero donde los vagones circulan por rizos y  sacacorchos",

--- a/objects/rct2/ride/rct2.bmair.json
+++ b/objects/rct2/ride/rct2.bmair.json
@@ -103,7 +103,7 @@
             "ru-RU": "Летающие горки"
         },
         "description": {
-            "en-GB": "Riders are held in comfortable seats below the track, travelling through twisted track to give the ultimate flying experience",
+            "en-GB": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
             "fr-FR": "Installés dans des sièges confortables, les passagers sont suspendus à une voie alambiquée leur donnant le sentiment de voler",
             "de-DE": "Die Passagiere sind in komfortablen Sitzen unter den Schienen und fahren entlang einer gewundenen Strecke, was ihnen das Gefühl gibt zu fliegen",
             "es-ES": "Los pasajeros están sentados confortablemente bajo la vía sintiendo una experiencia de casi-vuelo",

--- a/objects/rct2/ride/rct2.bmsd.json
+++ b/objects/rct2/ride/rct2.bmsd.json
@@ -105,7 +105,7 @@
             "ru-RU": "Твистер-коастер"
         },
         "description": {
-            "en-GB": "A spacious train with shoulder restraints",
+            "en-GB": "Spacious trains with shoulder restraints",
             "fr-FR": "De larges trains glissent le long de montagnes russes métalliques régulières proposant un grand éventail d'inversions",
             "de-DE": "Breite Achterbahnzüge gleiten auf glatten Stahlschienen mit verdrehter Streckenführung",
             "es-ES": "Montaña rusa amplia sobre vías de acero que efectúa varias inversiones",

--- a/objects/rct2/ride/rct2.bmvd.json
+++ b/objects/rct2/ride/rct2.bmvd.json
@@ -67,7 +67,7 @@
             "ru-RU": "Вертикальные горки"
         },
         "description": {
-            "en-GB": "Extra-wide cars descend completely vertical sloped track for the ultimate freefall roller coaster experience",
+            "en-GB": "Roller coaster trains with extra-wide cars, built for vertical drops",
             "fr-FR": "Des voitures très larges descendent des voies en pente verticale. Pour amateurs de chute libre",
             "de-DE": "Besonders breite Wagen fallen eine vollständige Vertikale herunter - das ultimative Erlebnis des freien Falls",
             "es-ES": "Vagones superanchos descienden completamente verticales para una experiencia definitiva",

--- a/objects/rct2/ride/rct2.bob1.json
+++ b/objects/rct2/ride/rct2.bob1.json
@@ -63,7 +63,7 @@
             "ru-RU": "Бобслей-поезд"
         },
         "description": {
-            "en-GB": "A train consisting of 2-seater cars where the riders are behind each other",
+            "en-GB": "Trains consisting of 2-seater cars where the riders are behind each other",
             "fr-FR": "Les passagers descendent un parcours plein de virages à bord d'une voiture en forme de bobsleigh dirigée uniquement par les courbes et l'inclinaison de la voie semi-circulaire",
             "de-DE": "Die Passagiere fahren in Bob-förmigen Wagen, die nur von der Krümmung und der seitlichen Neigung der halbkreisförmigen Strecke geführt werden, auf einer verdrehten Strecke",
             "es-ES": "Los pasajeros viajan por unas vías retorcidas en vagones tipo bobsleigh guiados únicamente por la curvatura y los peraltes de la vía semicircular",

--- a/objects/rct2/ride/rct2.ctcar.json
+++ b/objects/rct2/ride/rct2.ctcar.json
@@ -79,7 +79,7 @@
             "ru-RU": "Чешир"
         },
         "description": {
-            "en-GB": "Powered cat-shaped vehicles which follow a track-based route",
+            "en-GB": "Powered cat-shaped vehicles",
             "fr-FR": "Véhicule à propulsion en forme de chats se déplaçant sur une route plane",
             "de-DE": "Angetriebene Fahrzeuge in Katzenform, die einer Schienenstrecke folgen",
             "es-ES": "Vehículos autopropulsados con forma de gato que siguen la ruta de las vías",

--- a/objects/rct2/ride/rct2.ding1.json
+++ b/objects/rct2/ride/rct2.ding1.json
@@ -65,7 +65,7 @@
             "ru-RU": "Шлюпки"
         },
         "description": {
-            "en-GB": "Riders travel in inflatable dinghies down a twisting semi-circular or completely enclosed tube track",
+            "en-GB": "Inflatable dinghies that are twisting down a semi-circular or completely enclosed tube track",
             "fr-FR": "Les passagers descendent un tube semi-circulaire ou entièrement fermé à bord d'un canot pneumatique",
             "de-DE": "Die Passagiere fahren in Schlauchbooten eine sich windende, halbkreisförmige oder komplett in sich geschlossene Rohrstrecke herunter",
             "es-ES": "Los pasajeros viajan en botes hinchables por tubos semicirculares o totalmente cerrados",

--- a/objects/rct2/ride/rct2.ding1.json
+++ b/objects/rct2/ride/rct2.ding1.json
@@ -65,7 +65,7 @@
             "ru-RU": "Шлюпки"
         },
         "description": {
-            "en-GB": "Inflatable dinghies that are twisting down a semi-circular or completely enclosed tube track",
+            "en-GB": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
             "fr-FR": "Les passagers descendent un tube semi-circulaire ou entièrement fermé à bord d'un canot pneumatique",
             "de-DE": "Die Passagiere fahren in Schlauchbooten eine sich windende, halbkreisförmige oder komplett in sich geschlossene Rohrstrecke herunter",
             "es-ES": "Los pasajeros viajan en botes hinchables por tubos semicirculares o totalmente cerrados",

--- a/objects/rct2/ride/rct2.dodg1.json
+++ b/objects/rct2/ride/rct2.dodg1.json
@@ -66,8 +66,8 @@
             "ru-RU": "Кар"
         },
         "description": {
-            "en-GB": "Riders bump into each other in self-drive electric dodgems",
-            "en-US": "Riders bump into each other in self-driven electric bumper cars",
+            "en-GB": "Self-drive electric dodgems",
+            "en-US": "Self-driven electric bumper cars",
             "fr-FR": "Autos tamponneuses électriques",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos autopropulsados",

--- a/objects/rct2/ride/rct2.dodg1.json
+++ b/objects/rct2/ride/rct2.dodg1.json
@@ -66,8 +66,8 @@
             "ru-RU": "Кар"
         },
         "description": {
-            "en-GB": "Self-drive electric dodgem cars",
-            "en-US": "Self-driven electric bumper cars",
+            "en-GB": "Riders bump into each other in self-drive electric dodgems",
+            "en-US": "Riders bump into each other in self-driven electric bumper cars",
             "fr-FR": "Autos tamponneuses électriques",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos autopropulsados",

--- a/objects/rct2/ride/rct2.fsauc.json
+++ b/objects/rct2/ride/rct2.fsauc.json
@@ -57,7 +57,8 @@
             "ru-RU": "Тарелочки"
         },
         "description": {
-            "en-GB": "Riders ride in saucer-shaped hovercraft vehicles that they freely control",
+            "en-GB": "Self-drive saucer-shaped hovercraft vehicles",
+            "en-US": "Self-driven saucer-shaped hovercraft vehicles",
             "fr-FR": "Aéroglisseurs auto-guidés",
             "de-DE": "Selbstgesteuerte Luftkissenfahrzeuge",
             "es-ES": "Vehículos aerodeslizadores autopropulsados",

--- a/objects/rct2/ride/rct2.fsauc.json
+++ b/objects/rct2/ride/rct2.fsauc.json
@@ -57,7 +57,7 @@
             "ru-RU": "Тарелочки"
         },
         "description": {
-            "en-GB": "Self-drive hovercraft vehicles",
+            "en-GB": "Riders ride in saucer-shaped hovercraft vehicles that they freely control",
             "fr-FR": "Aéroglisseurs auto-guidés",
             "de-DE": "Selbstgesteuerte Luftkissenfahrzeuge",
             "es-ES": "Vehículos aerodeslizadores autopropulsados",

--- a/objects/rct2/ride/rct2.gtc.json
+++ b/objects/rct2/ride/rct2.gtc.json
@@ -89,7 +89,7 @@
             "ru-RU": "Призрак"
         },
         "description": {
-            "en-GB": "Powered monster shaped cars travel along a multi-level track past spooky scenery and special effects",
+            "en-GB": "Powered monster-shaped cars that run on a ghost train track",
             "fr-FR": "Des voitures en forme de monstres sont propulsées à travers plusieurs niveaux de décors et d'effets spéciaux effrayants",
             "de-DE": "Angetriebene Wagen in Monsterform fahren auf einer mehrstöckigen Strecke mit gruseliger Landschaft und Spezialeffekten",
             "es-ES": "Vagones con forma de monstruo en una vía múltiple pasando por un escenario tenebroso y lleno de efectos especiales",

--- a/objects/rct2/ride/rct2.helicar.json
+++ b/objects/rct2/ride/rct2.helicar.json
@@ -89,8 +89,8 @@
             "ru-RU": "Вертолётики"
         },
         "description": {
-            "en-GB": "Powered helicopter shaped cars running on a steel track, controlled by the pedalling of the riders",
-            "en-US": "Powered helicopter shaped cars running on a steel track, controlled by the pedaling of the riders",
+            "en-GB": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+            "en-US": "Powered helicopter-shaped cars, controlled by the pedaling of the riders",
             "fr-FR": "Installés dans des voitures en forme d'hélicoptère, les passagers parcourent une voie métallique en pédalant pour avancer",
             "de-DE": "Helikopterförmige Wagen fahren auf einer Stahlstrecke und werden von den Pedaltritten der Fahrer angetrieben",
             "es-ES": "Vagones con forma de helicópteros corren por una vía de acero controlados por los pedales de los pasajeros",

--- a/objects/rct2/ride/rct2.hmcar.json
+++ b/objects/rct2/ride/rct2.hmcar.json
@@ -90,7 +90,7 @@
             "ru-RU": "Гонки с призраками"
         },
         "description": {
-            "en-GB": "Powered cars travel along a multi-level track past special effects and scenery",
+            "en-GB": "Small powered cars that run on a ghost train track",
             "fr-FR": "Des voitures à propulsion parcourent les étages d'un bâtiment bourré d'effets spéciaux et de décors",
             "de-DE": "Angetriebene Wagen fahren auf einer mehrstöckigen Strecke an Spezialeffekten und Aufbauten vorbei",
             "es-ES": "Vagones autopropulsados que corren sobre una vía multinivel",

--- a/objects/rct2/ride/rct2.intinv.json
+++ b/objects/rct2/ride/rct2.intinv.json
@@ -67,7 +67,7 @@
             "ru-RU": "Обратно-импульсные горки"
         },
         "description": {
-            "en-GB": "Inverted roller coaster trains are accelerated out of the station to travel up a vertical spike of track, then reverse back through the station to travel backwards up another vertical spike of track",
+            "en-GB": "Inverted roller coaster trains for the Inverted Impulse Coaster",
             "fr-FR": "Les trains de montagnes russes à impulsion sont propulsés hors de la station puis, après avoir atteint une pointe verticale, redescendent vers la station et entament une nouvelle montée verticale en sens inverse",
             "de-DE": "Umgekehrte Achterbahnzüge werden aus der Station heraus auf einer vertikalen Strecke beschleunigt und kommen zurück zur Station, von wo sie rückwärts eine andere vertikale Strecke hinaufgeschossen werden",
             "es-ES": "Los vagones de la montaña rusa invertida aceleran saliendo del andén y toman un tramo de vía vertical, entonces vuelven marcha atrás pasando por el andén y subiendo por otro tramo de vía vertical",

--- a/objects/rct2/ride/rct2.ivmc1.json
+++ b/objects/rct2/ride/rct2.ivmc1.json
@@ -61,7 +61,7 @@
             "ru-RU": "Обратные поворот. горки"
         },
         "description": {
-            "en-GB": "Individual cars run beneath a zig-zagging track with hairpin turns and sharp drops",
+            "en-GB": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
             "fr-FR": "Des voitures individuelles placées sous la voie zigzaguent à travers les virages en épingle à cheveux et les chutes abruptes",
             "de-DE": "Einzelne Wagen fahren unter einer Zickzack-Strecke mit Haarnadelkurven und steilen Gefällen",
             "es-ES": "Vagones individuales corren bajo una vía zig-zageante",

--- a/objects/rct2/ride/rct2.kart1.json
+++ b/objects/rct2/ride/rct2.kart1.json
@@ -68,7 +68,7 @@
     "images": ["$RCT2:OBJDATA/KART1.DAT[0..210]"],
     "strings": {
         "name": {
-            "en-GB": "Go Karts",
+            "en-GB": "Go-Karts",
             "fr-FR": "Karting",
             "de-DE": "Go-Karts",
             "es-ES": "Karts",
@@ -84,8 +84,8 @@
             "ru-RU": "Картинг"
         },
         "description": {
-            "en-GB": "Self-drive petrol-engined go karts",
-            "en-US": "Self-drive gas-engined go karts",
+            "en-GB": "Riders race each other in self-drive petrol-engined go-karts",
+            "en-US": "Riders race each other in self-drive gas-engined go-karts",
             "fr-FR": "Karts individuels constitués de moteurs à essence",
             "de-DE": "Selbstbetriebene Benzin-Go-Karts",
             "es-ES": "Karts a gasolina autopropulsados",

--- a/objects/rct2/ride/rct2.kart1.json
+++ b/objects/rct2/ride/rct2.kart1.json
@@ -84,8 +84,8 @@
             "ru-RU": "Картинг"
         },
         "description": {
-            "en-GB": "Riders race each other in self-drive petrol-engined go-karts",
-            "en-US": "Riders race each other in self-drive gas-engined go-karts",
+            "en-GB": "Self-drive petrol-engined go-karts",
+            "en-US": "Self-driven gas-engined go-karts",
             "fr-FR": "Karts individuels constitués de moteurs à essence",
             "de-DE": "Selbstbetriebene Benzin-Go-Karts",
             "es-ES": "Karts a gasolina autopropulsados",

--- a/objects/rct2/ride/rct2.lfb1.json
+++ b/objects/rct2/ride/rct2.lfb1.json
@@ -79,7 +79,7 @@
             "ru-RU": "Ущелье"
         },
         "description": {
-            "en-GB": "Log-shaped boats travel along a water channel, splashing down steep slopes to soak the riders",
+            "en-GB": "Log-shaped boats built for running in water channels",
             "fr-FR": "Bateaux en forme de bûches géantes parcourant un tube aquatique dont les pentes abruptes auront pour effet de tremper les passagers",
             "de-DE": "Baumstammförmige Boote fahren in einem Wasserkanal und rutschen steile Gefälle herunter, damit die Fahrgäste unten nass werden",
             "es-ES": "Barcos con forma de tronco que viajan por un canal de agua, salpicando hasta empapar a los pasajeros",

--- a/objects/rct2/ride/rct2.monbk.json
+++ b/objects/rct2/ride/rct2.monbk.json
@@ -58,8 +58,8 @@
             "ru-RU": "Моноциклы"
         },
         "description": {
-            "en-GB": "Special bicycles run on a steel monorail track, propelled by the pedalling of the riders",
-            "en-US": "Special bicycles run on a steel monorail track, propelled by the pedaling of the riders",
+            "en-GB": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+            "en-US": "Special bicycles that run on a monorail track, propelled by the pedaling of the riders",
             "fr-FR": "Des vélos spéciaux parcourent une voie monorail métallique",
             "de-DE": "Spezielle Fahrräder fahren auf einer einschienigen Stahlstrecke und werden von den Passagieren angetrieben, indem sie in die Pedale treten",
             "es-ES": "Bicicletas especiales que recorren sobre un monorraíl, impulsadas por pedaleo",

--- a/objects/rct2/ride/rct2.nemt.json
+++ b/objects/rct2/ride/rct2.nemt.json
@@ -73,7 +73,7 @@
             "ru-RU": "Перевёрнутые горки"
         },
         "description": {
-            "en-GB": "Riders sit in seats suspended beneath the track as they speed through giant loops, twists, and large swooping drops",
+            "en-GB": "Suspended trains in which riders sit in rows",
             "fr-FR": "Les passagers parcourent des boucles géantes, des virages et des grandes descentes en piqué, installés sur des sièges suspendus à la voie",
             "de-DE": "Die Fahrgäste sind in Sitzen, die unter den Schienen hängen und durch riesige Schleifen, Kurven und große Gefälle rasen",
             "es-ES": "Los pasajeros se sientan en asientos suspendidos bajo la vía y corren por rizos gigantes, giros y grandes caídas",

--- a/objects/rct2/ride/rct2.obs1.json
+++ b/objects/rct2/ride/rct2.obs1.json
@@ -140,7 +140,7 @@
             "ru-RU": "Смотровая башня"
         },
         "description": {
-            "en-GB": "Rotating observation cabin which travels up a tall tower",
+            "en-GB": "Single-deck rotating observation cabin",
             "fr-FR": "Cabine rotative d'observation qui se hisse au sommet d'une grande tour",
             "de-DE": "Rotierende Aussichtskabine, die sich an einem hohen Turm hinauf bewegt",
             "es-ES": "Cabina de observación que viaja hasta una torre alta",

--- a/objects/rct2/ride/rct2.obs2.json
+++ b/objects/rct2/ride/rct2.obs2.json
@@ -144,7 +144,7 @@
             "ru-RU": "Наблюдательная башня"
         },
         "description": {
-            "en-GB": "Twin-deck rotating observation cabin which travels up a tall tower",
+            "en-GB": "Twin-deck rotating observation cabin",
             "fr-FR": "Cabine rotative d'observation à double pont qui se hisse au sommet d'une grande tour",
             "de-DE": "Rotierende Doppeldecker-Aussichtskabine, die sich an einem hohen Turm hinauf bewegt",
             "es-ES": "Cabinas de observación con doble piso que viajan verticalmente en una torre alta",

--- a/objects/rct2/ride/rct2.pmt1.json
+++ b/objects/rct2/ride/rct2.pmt1.json
@@ -100,7 +100,7 @@
             "ru-RU": "Рудник"
         },
         "description": {
-            "en-GB": "Powered mine trains career along a smooth and twisted track layout",
+            "en-GB": "Mine train-themed roller coaster trains that propel themselves",
             "fr-FR": "Train de mine à propulsion franchissant une voie régulière et alambiquée",
             "de-DE": "Angetriebene Minenzüge fahren auf einer gemäßigten und verwundenen Strecke",
             "es-ES": "Trenes mineros autopropulsados corren a lo largo de una vía enredada",

--- a/objects/rct2/ride/rct2.premt1.json
+++ b/objects/rct2/ride/rct2.premt1.json
@@ -110,7 +110,7 @@
             "ru-RU": "Горки на LIM"
         },
         "description": {
-            "en-GB": "Roller coaster trains are accelerated out of the station by linear induction motors to speed through twisting inversions",
+            "en-GB": "Roller coaster trains that are accelerated by linear induction motors",
             "fr-FR": "Train de montagnes russes propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversion renversantes",
             "de-DE": "Achterbahnzüge werden aus der Station mit Hilfe von linearen Induktionsmotoren beschleunigt und rasen durch gewundene Ueberkopfteile",
             "es-ES": "Los vagones se aceleran por los motores lineales de inducción",

--- a/objects/rct2/ride/rct2.rapboat.json
+++ b/objects/rct2/ride/rct2.rapboat.json
@@ -76,7 +76,7 @@
             "ru-RU": "Перекаты"
         },
         "description": {
-            "en-GB": "Circular boats meander along a wide water channel, splashing through waterfalls and thrilling riders through foaming rapids",
+            "en-GB": "Circular boats that turn and splash around as they meander along the river rapids",
             "fr-FR": "Des bateaux de forme circulaire serpentent le long d'un large cours d'eau, puis dévalent des rapides et des chutes d'eau spectaculaires",
             "de-DE": "Runde Boote winden sich durch einen breiten Wasserkanal, platschen dabei durch Wasserfälle und aufregende, schäumende Stromschnellen",
             "es-ES": "Botes circulares que corren por canales de agua salpicando",

--- a/objects/rct2/ride/rct2.rftboat.json
+++ b/objects/rct2/ride/rct2.rftboat.json
@@ -63,7 +63,7 @@
             "ru-RU": "Рафтинг"
         },
         "description": {
-            "en-GB": "Raft-shaped boats gently meander around a river track",
+            "en-GB": "Raft-shaped boats built for flat river tracks",
             "fr-FR": "Des bateaux en forme de radeau descendent paisiblement une voie navigable",
             "de-DE": "Floßförmige Boote winden sich sanft durch eine Flussstrecke",
             "es-ES": "Botes con forma de balsa",

--- a/objects/rct2/ride/rct2.skytr.json
+++ b/objects/rct2/ride/rct2.skytr.json
@@ -68,7 +68,7 @@
             "ru-RU": "Мини-летающие горки"
         },
         "description": {
-            "en-GB": "Passengers ride face-down in a lying position, suspended in a specially designed car from the single-rail track, swinging freely from side to side around corners",
+            "en-GB": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
             "fr-FR": "Les passagers sont couchés à plat ventre dans une voiture spéciale se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
             "de-DE": "Die Passagiere fahren kopfüber liegend und hängen dabei in einem speziell entworfenen Wagen von einer Einschienenstrecke, wobei sie in den Kurven frei von Seite zu Seite schwingen.",
             "es-ES": "Los pasajeros se colocan boca abajo en unos vagones especiales en ésta montaña rusa",

--- a/objects/rct2/ride/rct2.slct.json
+++ b/objects/rct2/ride/rct2.slct.json
@@ -71,7 +71,7 @@
             "ru-RU": "Компактные горки"
         },
         "description": {
-            "en-GB": "Riders sit in pairs of seats suspended beneath the track as they loop and twist through tight inversions",
+            "en-GB": "Riders sit in pairs of seats suspended beneath the track",
             "fr-FR": "Les passagers sont assis par deux, suspendus à la voie tandis qu'ils zigzaguent et sont chahutés lors d'inversions serrées",
             "de-DE": "Die Fahrgäste hängen in Sitzpaaren unter der Strecke und fahren Schleifen und Wendungen durch enge Kurven",
             "es-ES": "Los pasajeros se sientan en parejas atravesando rizos e inversiones",

--- a/objects/rct2/ride/rct2.spboat.json
+++ b/objects/rct2/ride/rct2.spboat.json
@@ -92,7 +92,7 @@
             "ru-RU": "Лодки"
         },
         "description": {
-            "en-GB": "Large capacity boats travel along a wide water channel, propelled up slopes by a conveyor belt, accelerating down steep slopes to soak the riders with a giant splash",
+            "en-GB": "Large capacity boats, built for water tracks with very steep drops",
             "fr-FR": "Grand bateau qui serpente le long d'une large voie navigable, monte sur des pentes grâce à un tapis roulant, et descend à toute vitesse de l'autre côté, éclaboussant allègrement les passagers",
             "de-DE": "Große Boote bewegen sich in einem breiten Wasserkanal, fahren von einem Fließband befördert Anstiege hoch und sausen steile Gefälle hinunter, damit die Fahrgäste mit einem gigantischen Platscher durchnässt werden",
             "es-ES": "Botes de gran capacidad que viajan por un amplio canal impulsados por una cinta transportadora que producen grandes salpicaduras",

--- a/objects/rct2/ride/rct2.spcar.json
+++ b/objects/rct2/ride/rct2.spcar.json
@@ -59,7 +59,7 @@
     "images": ["$RCT2:OBJDATA/SPCAR.DAT[0..242]"],
     "strings": {
         "name": {
-            "en-GB": "Sportscars",
+            "en-GB": "Sports Cars",
             "fr-FR": "Voitures de sport",
             "de-DE": "Sportwagen",
             "es-ES": "Deportivos",
@@ -76,7 +76,7 @@
             "ru-RU": "Спорткары"
         },
         "description": {
-            "en-GB": "Powered vehicles in the shape of sportscars",
+            "en-GB": "Powered vehicles in the shape of sports cars",
             "fr-FR": "Véhicules à propulsion en forme de voitures de sport",
             "de-DE": "Angetriebene Fahrzeuge in Form von Sportwagen",
             "es-ES": "Vehículos autopropulsados de forma de carreras",

--- a/objects/rct2/ride/rct2.swans.json
+++ b/objects/rct2/ride/rct2.swans.json
@@ -61,7 +61,7 @@
         },
         "description": {
             "en-GB": "Swan-shaped boats, propelled by the pedalling front seat passengers",
-            "en-US": "Swan shaped boat, propelled by the pedaling front seat passengers",
+            "en-US": "Swan-shaped boats, propelled by the pedaling front seat passengers",
             "fr-FR": "Pédalos en forme de cygne",
             "de-DE": "Schwanförmiges Boot mit Pedalantrieb, das von den vorderen Passagieren getreten wird",
             "es-ES": "Bote con forma de cisne impulsado mediante pedaleo por los pasajeros",

--- a/objects/rct2/ride/rct2.swans.json
+++ b/objects/rct2/ride/rct2.swans.json
@@ -60,7 +60,7 @@
             "ru-RU": "Лебеди"
         },
         "description": {
-            "en-GB": "Swan shaped boat, propelled by the pedalling front seat passengers",
+            "en-GB": "Swan-shaped boats, propelled by the pedalling front seat passengers",
             "en-US": "Swan shaped boat, propelled by the pedaling front seat passengers",
             "fr-FR": "Pédalos en forme de cygne",
             "de-DE": "Schwanförmiges Boot mit Pedalantrieb, das von den vorderen Passagieren getreten wird",

--- a/objects/rct2/ride/rct2.thcar.json
+++ b/objects/rct2/ride/rct2.thcar.json
@@ -86,7 +86,7 @@
             "ru-RU": "Воздушные горки"
         },
         "description": {
-            "en-GB": "After an exhilarating air-powered launch, the train speeds up a vertical track, over the top, and vertically down the other side to return to the station",
+            "en-GB": "Air-powered launched roller coaster trains",
             "fr-FR": "Après avoir été propulsé dans les airs, le train accélère sur une voie verticale, passe le sommet, et retombe de l'autre côté en direction de la station",
             "de-DE": "Nach einem atemberaubenden luftbetriebenen Start schnellt der Zug eine vertikale Strecke hoch, über die Spitze und auf der anderen Seite vertikal nach unten zurück zur Station",
             "es-ES": "Tras un excitante lanzamiento el vagón corre por una vía vertical hasta el tope y baja vertical por el otro lado",

--- a/objects/rct2/ride/rct2.vcr.json
+++ b/objects/rct2/ride/rct2.vcr.json
@@ -79,7 +79,7 @@
             "ru-RU": "Ретрокары"
         },
         "description": {
-            "en-GB": "Powered vehicles in the shape of vintage cars which follow a track-based route",
+            "en-GB": "Powered vehicles in the shape of vintage cars",
             "fr-FR": "Véhicule à propulsion en forme de voiture ancienne et parcourant une route plane",
             "de-DE": "Angetriebene Fahrzeuge in Form von Oldie-Wagen, die auf einer Schienenstrecke fahren",
             "es-ES": "Vehículos con forma de coches antiguos que recorren una vía",

--- a/objects/rct2/ride/rct2.vekdv.json
+++ b/objects/rct2/ride/rct2.vekdv.json
@@ -70,7 +70,7 @@
             "ru-RU": "Вертикальный челнок"
         },
         "description": {
-            "en-GB": "Riders sit in cars suspended beneath the track, pulled backwards up a vertical track and then dropped to loop and twist around tight inversions",
+            "en-GB": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
             "fr-FR": "Voitures suspendues à la voie, hissées en marche arrière au sommet d'une voie verticale, puis lâchées  dans un parcours fait de boucles et d'inversions serrées",
             "de-DE": "Die Fahrgäste sitzen in Wagen, die unter den Schienen hängen, werden rückwärts eine vertikale Strecke hochgezogen und dann fallengelassen, um durch Schleifen, Schrauben und andere Ueberkopfteile zu rasen",
             "es-ES": "Los pasajeros están sentados suspendidos bajo la vía",

--- a/objects/rct2/ride/rct2.vekst.json
+++ b/objects/rct2/ride/rct2.vekst.json
@@ -102,8 +102,8 @@
             "ru-RU": "Лежачие горки"
         },
         "description": {
-            "en-GB": "Riders are held in special harnesses in a lying-down position, travelling through twisted track and inversions either on their backs or facing the ground",
-            "en-US": "Riders are held in special harnesses in a lying-down position, traveling through twisted track and inversions either on their backs or facing the ground",
+            "en-GB": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+            "en-US": "Riders are held in special harnesses in a lying-down position, traveling either on their backs or facing the ground",
             "fr-FR": "Les passagers franchissent une voie alambiquée pleine d'inversions, couchés à plat ventre ou sur le dos, et maintenus par des harnais spéciaux",
             "de-DE": "Die Passagiere befinden sich in speziellen Haltevorrichtungen in liegender Position (entweder auf dem Rücken oder dem Bauch) und fahren auf einer gewundenen Strecke mit Ueberkopfteilen",
             "es-ES": "Los pasajeros están sujetos por unos arneses cara abajo",

--- a/objects/rct2/ride/rct2.vekvamp.json
+++ b/objects/rct2/ride/rct2.vekvamp.json
@@ -73,7 +73,7 @@
             "ru-RU": "Вагончики"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of chairlift style seats able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
             "fr-FR": "Train de montagnes russes suspendu et composé de télésièges qui se balancent librement dans les virages",
             "de-DE": "Hängender Achterbahnzug mit Sessellift-artigen Sitzen, die in Kurven frei schwingen können",
             "es-ES": "Vagones suspendidos como en los telesilla que pueden balancearse libremente en las curvas",

--- a/objects/rct2/ride/rct2.vreel.json
+++ b/objects/rct2/ride/rct2.vreel.json
@@ -60,7 +60,7 @@
             "ru-RU": "Вирджиния"
         },
         "description": {
-            "en-GB": "Circular cars spin around as they travel along the zig-zagging wooden track",
+            "en-GB": "Circular cars that spin around as they travel along the track",
             "fr-FR": "Voitures de forme circulaire tournant sur elles-même tout en parcourant une voie en bois faite de zigzags",
             "de-DE": "Runde Wagen drehen sich auf der Zickzack-Holzstrecke",
             "es-ES": "Vagones circulares que rebotan mientras corren sobre la pista de madera en zigzag",

--- a/objects/rct2/ride/rct2.wmspin.json
+++ b/objects/rct2/ride/rct2.wmspin.json
@@ -67,7 +67,7 @@
             "ru-RU": "Вращающаяся мышка"
         },
         "description": {
-            "en-GB": "Mouse shaped cars speed through tight corners and short drops, gently spinning around to disorientate the riders",
+            "en-GB": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
             "fr-FR": "Voiture en forme de souris fonçant dans des virages serrés et des petites chutes, tout en tournant sur elle-même afin de désorienter les passagers",
             "de-DE": "Mausförmige Wagen rasen um enge Kurven und kurze Gefälle herunter, wobei sie sich sanft drehen, um die Fahrgäste zu desorientieren",
             "es-ES": "Vagones con forma de ratón efectúan curvas bruscas",

--- a/objects/rct2/ride/rct2.zldb.json
+++ b/objects/rct2/ride/rct2.zldb.json
@@ -110,7 +110,7 @@
             "ru-RU": "Божья Коровка"
         },
         "description": {
-            "en-GB": "Roller coaster trains with small ladybird shaped cars",
+            "en-GB": "Roller coaster trains with small ladybird-shaped cars",
             "fr-FR": "Train de montagne russe avec des voitures en forme de coccinelle",
             "de-DE": "Achterbahnzüge mit kleinen Marienkäferwagen",
             "es-ES": "Montaña rusa con vagones de forma de mariquitas",

--- a/objects/rct2/ride/rct2.zlog.json
+++ b/objects/rct2/ride/rct2.zlog.json
@@ -112,7 +112,7 @@
             "ru-RU": "Бревна"
         },
         "description": {
-            "en-GB": "Roller coaster trains with small log shaped cars",
+            "en-GB": "Roller coaster trains with small log-shaped cars",
             "fr-FR": "Train de montagnes russes composé de petites voitures en forme de bûche",
             "de-DE": "Achterbahnzüge mit kleinen baumstammförmigen Wagen",
             "es-ES": "Montaña rusa con vagones en forma de tronco",

--- a/objects/rct2tt/ride/rct2.tt.1920racr.json
+++ b/objects/rct2tt/ride/rct2.tt.1920racr.json
@@ -69,7 +69,7 @@
     "images": ["$RCT2:OBJDATA/1920RACR.DAT[0..210]"],
     "strings": {
         "name": {
-            "en-GB": "1920's Racing Cars",
+            "en-GB": "1920s Racing Cars",
             "fr-FR": "Voitures de course des années folles",
             "de-DE": "Rennwagen der Zwanziger",
             "es-ES": "Coches de carreras de los años 20",
@@ -84,7 +84,7 @@
             "ru-RU": "Машинки 1920гг"
         },
         "description": {
-            "en-GB": "1920's race car themed go-karts",
+            "en-GB": "1920s race car themed go-karts",
             "fr-FR": "Les passagers font la course à bord de karts représentant des voitures des années folles",
             "de-DE": "Die Fahrer fahren Rennen mit Gokarts aus den Zwanzigern.",
             "es-ES": "Los usuarios compiten en karts con forma de coches de carreras de los años 20.",

--- a/objects/rct2tt/ride/rct2.tt.1920racr.json
+++ b/objects/rct2tt/ride/rct2.tt.1920racr.json
@@ -84,7 +84,7 @@
             "ru-RU": "Машинки 1920гг"
         },
         "description": {
-            "en-GB": "Riders race each other in 1920's race car themed go-karts",
+            "en-GB": "1920's race car themed go-karts",
             "fr-FR": "Les passagers font la course à bord de karts représentant des voitures des années folles",
             "de-DE": "Die Fahrer fahren Rennen mit Gokarts aus den Zwanzigern.",
             "es-ES": "Los usuarios compiten en karts con forma de coches de carreras de los años 20.",

--- a/objects/rct2tt/ride/rct2.tt.barnstrm.json
+++ b/objects/rct2tt/ride/rct2.tt.barnstrm.json
@@ -64,7 +64,8 @@
             "ru-RU": "Гастрольные горки"
         },
         "description": {
-            "en-GB": "Riders sit in seats suspended beneath the track as they speed through giant loops, twists, and large swooping drops",
+            "en-GB": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+            "en-US": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker airplanes",
             "fr-FR": "Les passagers parcourent des boucles géantes, des virages et des grandes descentes en piqué, installés sur des sièges suspendus à la voie",
             "de-DE": "Die Sitze befinden sich unter der Spur und rasen durch riesige Loopings, Drehungen und große, plötzliche Gefälle hinab.",
             "es-ES": "Los usuarios se sientan suspendidos debajo de la estructura, pasando a toda velocidad por bucles gigantes, giros y grandes caídas en picado.",

--- a/objects/rct2tt/ride/rct2.tt.blckdeth.json
+++ b/objects/rct2tt/ride/rct2.tt.blckdeth.json
@@ -60,7 +60,7 @@
             "ru-RU": "Чёрная Смерть"
         },
         "description": {
-            "en-GB": "Riders career down a twisting track in rat-shaped cars guided only by the curvature and banking of the semi-circular track",
+            "en-GB": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
             "fr-FR": "Les passagers descendent un parcours alambiqué à bord d'une grande voiture en forme de rat dirigée uniquement par les courbes et l'inclinaison de la voie semi-circulaire",
             "de-DE": "Die Fahrer rasen in Ratten-artigen Wagen eine gewundene Strecke hinab, wobei sie nur durch die Kurvenführung der halbrunden Strecke geführt werden.",
             "es-ES": "Los usuarios recorren, en coches en forma de rata, una ruta guiada únicamente por la curvatura y el desnivel del recorrido semicircular.",

--- a/objects/rct2tt/ride/rct2.tt.bmvoctps.json
+++ b/objects/rct2tt/ride/rct2.tt.bmvoctps.json
@@ -141,7 +141,7 @@
             "ru-RU": "Падение из космоса"
         },
         "description": {
-            "en-GB": "A themed rotating observation cabin which travels up a tall tower",
+            "en-GB": "A themed rotating observation cabin",
             "fr-FR": "Une cabine thématique rotative qui se hisse le long d'une immense tour",
             "de-DE": "Eine rotierende Aussichtskabine, die einen großen Turm hinauffährt",
             "es-ES": "Cabina de observación rotatoria decorada",

--- a/objects/rct2tt/ride/rct2.tt.bmvoctps.json
+++ b/objects/rct2tt/ride/rct2.tt.bmvoctps.json
@@ -141,7 +141,8 @@
             "ru-RU": "Падение из космоса"
         },
         "description": {
-            "en-GB": "A themed rotating observation cabin",
+            "en-GB": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+            "en-US": "A themed rotating observation cabin shaped like a blob from a sci-fi B-movie",
             "fr-FR": "Une cabine thématique rotative qui se hisse le long d'une immense tour",
             "de-DE": "Eine rotierende Aussichtskabine, die einen großen Turm hinauffährt",
             "es-ES": "Cabina de observación rotatoria decorada",

--- a/objects/rct2tt/ride/rct2.tt.cavmncar.json
+++ b/objects/rct2tt/ride/rct2.tt.cavmncar.json
@@ -84,7 +84,8 @@
             "ru-RU": "Пещ. машины"
         },
         "description": {
-            "en-GB": "Riders race each other in Stone Age go-karts",
+            "en-GB": "Self-drive go-karts in Stone Age style",
+            "en-US": "Self-driven go-karts in Stone Age style",
             "fr-FR": "Les passagers font la course à bord de karts préhistoriques",
             "de-DE": "Die Fahrer fahren Rennen mit Gokarts aus der Steinzeit",
             "es-ES": "Los usuarios compiten en los karts de la edad de piedra",

--- a/objects/rct2tt/ride/rct2.tt.cerberus.json
+++ b/objects/rct2tt/ride/rct2.tt.cerberus.json
@@ -105,7 +105,7 @@
             "ru-RU": "Горки Цербер"
         },
         "description": {
-            "en-GB": "Spacious trains with simple lap restraints with cars shaped like a multi-headed dog from the Underworld",
+            "en-GB": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
             "fr-FR": "Retenus uniquement par les jambes dans des voitures confortables, les visiteurs effectuent des descentes géantes le long d'un tracé sinueux et décollent de leur siège en haut des collines",
             "de-DE": "In bequemen Wagen mit einfacher Rückhaltevorrichtung genießen die Fahrgäste sanfte Stürze, eine kurvenreiche Strecke und einen schönen, ausgedehnten Ausblick über die Hügel.",
             "es-ES": "Sentados en cómodos vagones con sujeciones simples, los viajeros disfrutan de grandes y suaves caídas así como de giros y gran cantidad de momentos de caída libre en los puntos superiores.",

--- a/objects/rct2tt/ride/rct2.tt.cerberus.json
+++ b/objects/rct2tt/ride/rct2.tt.cerberus.json
@@ -105,7 +105,7 @@
             "ru-RU": "Горки Цербер"
         },
         "description": {
-            "en-GB": "Sitting in comfortable trains with only simple lap restraints riders enjoy giant smooth drops and twisting track as well as plenty of 'air time' over the hills",
+            "en-GB": "Spacious trains with simple lap restraints with cars shaped like a multi-headed dog from the Underworld",
             "fr-FR": "Retenus uniquement par les jambes dans des voitures confortables, les visiteurs effectuent des descentes géantes le long d'un tracé sinueux et décollent de leur siège en haut des collines",
             "de-DE": "In bequemen Wagen mit einfacher Rückhaltevorrichtung genießen die Fahrgäste sanfte Stürze, eine kurvenreiche Strecke und einen schönen, ausgedehnten Ausblick über die Hügel.",
             "es-ES": "Sentados en cómodos vagones con sujeciones simples, los viajeros disfrutan de grandes y suaves caídas así como de giros y gran cantidad de momentos de caída libre en los puntos superiores.",

--- a/objects/rct2tt/ride/rct2.tt.dragnfly.json
+++ b/objects/rct2tt/ride/rct2.tt.dragnfly.json
@@ -60,7 +60,7 @@
             "ru-RU": "Стрекоза"
         },
         "description": {
-            "en-GB": "Passengers ride suspended in a specially designed car from the single-rail track, swinging freely from side to side around corners",
+            "en-GB": "Dragonfly-shaped cars which swing from the rail above",
             "fr-FR": "Les passagers voyagent dans une voiture spécialement conçue, suspendue à un rail, et qui se balance dans les virages",
             "de-DE": "Die Fahrgäste fahren in einem besonders dafür gebauten Wagen auf der Einschienen-Strecke und schwingen in den Kurven frei hin und her.",
             "es-ES": "Los pasajeros viajan suspendidos en vagones especialmente diseñados unidos a una vía monorraíl, con libertad para balancearse en las curvas.",

--- a/objects/rct2tt/ride/rct2.tt.figtknit.json
+++ b/objects/rct2tt/ride/rct2.tt.figtknit.json
@@ -48,6 +48,7 @@
     "strings": {
         "name": {
             "en-GB": "Fighting Knights Dodgems",
+            "en-US": "Fighting Knights Bumper Cars",
             "fr-FR": "Auto-tamponneuses des chevaliers",
             "de-DE": "Kampfritter-Autoskooterwagen",
             "es-ES": "Coches de choque Caballeros en combate",
@@ -62,7 +63,8 @@
             "ru-RU": "Рыцари"
         },
         "description": {
-            "en-GB": "Riders joust on horse-themed dodgem cars",
+            "en-GB": "Riders joust on horse-themed dodgems",
+            "en-US": "Riders joust on horse-themed bumper cars",
             "fr-FR": "Les passagers participent à un tournoi médiéval d'auto-tamponneuses",
             "de-DE": "Die Fahrer kämpfen im Autoskooter auf Pferdewagen.",
             "es-ES": "Los usuarios se suben en coches de choque decorados como caballos.",

--- a/objects/rct2tt/ride/rct2.tt.flwrpowr.json
+++ b/objects/rct2tt/ride/rct2.tt.flwrpowr.json
@@ -60,7 +60,7 @@
             "ru-RU": "Цветок"
         },
         "description": {
-            "en-GB": "Small flower-shaped hovercraft vehicles powered by a centrally-mounted motor controlled by the passengers",
+            "en-GB": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
             "fr-FR": "Petits canots pneumatiques en forme de fleurs alimentés par un moteur central que contrôlent les passagers",
             "de-DE": "Kleine Schlauchboote in Blumenform, die durch einen in der Mitte angebrachten Motor betrieben und von den Fahrgästen gesteuert werden.",
             "es-ES": "Pequeños botes decorados como flores controlados por un monitor central que controlan los pasajeros.",

--- a/objects/rct2tt/ride/rct2.tt.flygboat.json
+++ b/objects/rct2tt/ride/rct2.tt.flygboat.json
@@ -89,7 +89,7 @@
             "ru-RU": "Парящая лодка"
         },
         "description": {
-            "en-GB": "Flying Boat shaped cars run on roller coaster track to allow twisting curves and steep drops, splashing down into sections of water for gentle river sections",
+            "en-GB": "Roller coaster cars shaped like flying boats",
             "fr-FR": "Des voitures en forme de bateau franchissent des virages serrés et des descentes abruptes, et plongent dans des zones aquatiques",
             "de-DE": "Die Wagen in Form von Fliegenden Schiffen fahren auf einer kurvenreichen Achterbahnstrecke mit steilem Gefälle, Wasserspektakel und sanften Flussabschnitten.",
             "es-ES": "Los vagones en forma de bote volante corren por el recorrido de la montaña rusa, con curvas cerradas y caídas pronunciadas, pasando por zonas de agua.",

--- a/objects/rct2tt/ride/rct2.tt.harpiesx.json
+++ b/objects/rct2tt/ride/rct2.tt.harpiesx.json
@@ -98,7 +98,8 @@
             "ru-RU": "Гарпии"
         },
         "description": {
-            "en-GB": "Riders are held in special harnesses in a lying-down position, travelling through twisted track and inversions either on their backs or facing the ground",
+            "en-GB": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+            "en-US": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, traveling either on their backs or facing the ground",
             "fr-FR": "Les passagers franchissent une voie alambiquée pleine d'inversions, couchés à plat ventre ou sur le dos, et maintenus par des harnais spéciaux",
             "de-DE": "Die Fahrer sind mit speziellen Gurten auf dem Rücken oder auf dem Bauch liegend angeschnallt und fahren über kurvenreiche, verdrehte Strecken.",
             "es-ES": "Los usuarios están sujetos con arneses especiales para quedar en una posición tumbada y viajar por un circuito lleno de giros e inversiones, bien sobre las espaldas o de cara al suelo.",

--- a/objects/rct2tt/ride/rct2.tt.hotrodxx.json
+++ b/objects/rct2tt/ride/rct2.tt.hotrodxx.json
@@ -84,7 +84,7 @@
             "ru-RU": "Горки-Хотрод"
         },
         "description": {
-            "en-GB": "After an exhilarating air-powered launch, the train speeds up a vertical track, over the top, and vertically down the other side to return to the station",
+            "en-GB": "Air-powered launched roller coaster trains in the shape of hot rod cars",
             "fr-FR": "Après avoir été propulsé dans les airs, le train accélère sur une voie verticale, passe le sommet, et retombe de l'autre côté en direction de la station",
             "de-DE": "Der Zug wird durch Luftdruck aus der Station katapultiert, fährt senkrecht hinauf und auf der anderen Seite wieder senkrecht hinunter.",
             "es-ES": "Después de un divertido lanzamiento por aire, el tren acelera por una vía vertical, hasta lo más alto, viajando verticalmente por el otro lado para llegar a la estación.",

--- a/objects/rct2tt/ride/rct2.tt.hoverbke.json
+++ b/objects/rct2tt/ride/rct2.tt.hoverbke.json
@@ -60,7 +60,7 @@
             "ru-RU": "Ховербайки"
         },
         "description": {
-            "en-GB": "Riders sit on futuristic bike-shaped vehicles which travel along a single-rail track",
+            "en-GB": "Futuristic bike-shaped single vehicles",
             "fr-FR": "Les passagers prennent place à bord de véhicules en forme de motos qui dévalent une voie monorail",
             "de-DE": "Die Fahrer fahren auf futuristischen Fahrrädern über eine Einschienen-Strecke",
             "es-ES": "Los viajeros se sientan en vehículos con forma de moto que viajan por un monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.jetpackx.json
+++ b/objects/rct2tt/ride/rct2.tt.jetpackx.json
@@ -61,7 +61,7 @@
             "ru-RU": "Бустер"
         },
         "description": {
-            "en-GB": "Riders sit in a vehicle which is launched up a vertical section of track",
+            "en-GB": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
             "fr-FR": "Les passagers sont installés dans un véhicule propulsé sur une paroi verticale",
             "de-DE": "Die Fahrgäste sitzen in einem Wagen, der senkrecht hinaufkatapultiert wird.",
             "es-ES": "Los viajeros se montan en un vehículo que se lanza por un guía vertical.",

--- a/objects/rct2tt/ride/rct2.tt.jousting.json
+++ b/objects/rct2tt/ride/rct2.tt.jousting.json
@@ -56,7 +56,7 @@
             "ru-RU": "Рыцарские горки"
         },
         "description": {
-            "en-GB": "Single horse-shaped vehicles",
+            "en-GB": "Separate horse-shaped vehicles",
             "fr-FR": "Les passagers voyagent à bord de véhicules en forme de chevaux le long d'une voie monorail",
             "de-DE": "Die Fahrgäste sitzen auf dem Rücken von Pferde-artigen Wagen auf einer Einschienen-Strecke.",
             "es-ES": "Los pasajeros se montan en la grupa de vehículos en forma de caballos que van por una vía monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.jousting.json
+++ b/objects/rct2tt/ride/rct2.tt.jousting.json
@@ -56,7 +56,7 @@
             "ru-RU": "Рыцарские горки"
         },
         "description": {
-            "en-GB": "Riders sit on the back of horse-shaped vehicles along a single-rail track",
+            "en-GB": "Single horse-shaped vehicles",
             "fr-FR": "Les passagers voyagent à bord de véhicules en forme de chevaux le long d'une voie monorail",
             "de-DE": "Die Fahrgäste sitzen auf dem Rücken von Pferde-artigen Wagen auf einer Einschienen-Strecke.",
             "es-ES": "Los pasajeros se montan en la grupa de vehículos en forma de caballos que van por una vía monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.medisoup.json
+++ b/objects/rct2tt/ride/rct2.tt.medisoup.json
@@ -35,7 +35,7 @@
             "ru-RU": "Супчик"
         },
         "description": {
-            "en-GB": "A Stall selling a thick broth style soup",
+            "en-GB": "A stall selling a thick broth-style soup",
             "fr-FR": "Restaurant proposant un bouillon épais",
             "de-DE": "Ein Stand, der eine dickflüssige Fleischbrühe verkauft",
             "es-ES": "Un puesto en el que se vende caldo tradicional",

--- a/objects/rct2tt/ride/rct2.tt.oakbarel.json
+++ b/objects/rct2tt/ride/rct2.tt.oakbarel.json
@@ -74,7 +74,7 @@
             "ru-RU": "Дубовая Бочка"
         },
         "description": {
-            "en-GB": "Oak barrels meander along a wide water channel, splashing through waterfalls and thrilling riders through foaming rapids",
+            "en-GB": "Oak barrels that turn and splash around as they meander along the river rapids",
             "fr-FR": "Des tonneaux serpentent le long d'un large cours d'eau, puis dévalent des rapides et des chutes d'eau spectaculaires",
             "de-DE": "Eichenfässer gleiten durch einen breiten Wasserkanal, zischen durch Wasserfälle und schäumende Stromschnellen.",
             "es-ES": "Los barriles de roble van a la deriva por un ancho canal de agua, cayendo por cataratas y pasando por estremecedores rápidos.",

--- a/objects/rct2tt/ride/rct2.tt.pegasusx.json
+++ b/objects/rct2tt/ride/rct2.tt.pegasusx.json
@@ -81,7 +81,7 @@
             "ru-RU": "Пегас"
         },
         "description": {
-            "en-GB": "Powered vehicles in the shape of Pegasus drawing a cart, follow a track-based route",
+            "en-GB": "Powered vehicles in the shape of Pegasus drawing a cart",
             "fr-FR": "Véhicule à propulsion en forme de Pégase tirant une charrette et parcourant une route plane",
             "de-DE": "Direkt angetriebene Fahrzeuge in Form eines Pegasus ziehen einen Wagen über die Schienentrassen.",
             "es-ES": "Poderosos vehículos en forma de pegaso tiran de un carro, siguiendo una ruta prefijada.",

--- a/objects/rct2tt/ride/rct2.tt.pterodac.json
+++ b/objects/rct2tt/ride/rct2.tt.pterodac.json
@@ -101,7 +101,7 @@
             "ru-RU": "Птеродактиль"
         },
         "description": {
-            "en-GB": "Riders are held in comfortable seats below the track, travelling through twisted track to give the ultimate prehistoric flying experience",
+            "en-GB": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
             "fr-FR": "Les passagers sont confortablement assis et voyagent suspendus à une voie en zigzag offrant des sensations de vol préhistorique",
             "de-DE": "Die Fahrer sitzen in bequemen Sitzen unterhalb der verschlungenen Strecke mit ultimativer prähistorischer Flugerfahrung.",
             "es-ES": "Los pasajeros se acomodan en asientos debajo de la vía, viajando por un retorcido circuito que les proporciona la experiencia definitiva de vuelo prehistórico.",

--- a/objects/rct2tt/ride/rct2.tt.raptorxx.json
+++ b/objects/rct2tt/ride/rct2.tt.raptorxx.json
@@ -58,7 +58,7 @@
             "ru-RU": "Раптор Рейсерс"
         },
         "description": {
-            "en-GB": "Riders sit on the back of raptor-shaped vehicles along a single-rail track",
+            "en-GB": "Single raptor-shaped vehicles",
             "fr-FR": "Les passagers voyagent à l'arrière de véhicules en forme de raptor sur une voie monorail",
             "de-DE": "Die Fahrgäste sitzen auf dem Rücken von Raptor-artigen Wagen auf einer Einschienen-Strecke.",
             "es-ES": "Los usuarios se sientan en vehículos con forma de velocirraptor, en un circuito monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.raptorxx.json
+++ b/objects/rct2tt/ride/rct2.tt.raptorxx.json
@@ -58,7 +58,7 @@
             "ru-RU": "Раптор Рейсерс"
         },
         "description": {
-            "en-GB": "Single raptor-shaped vehicles",
+            "en-GB": "Separate raptor-shaped vehicles",
             "fr-FR": "Les passagers voyagent à l'arrière de véhicules en forme de raptor sur une voie monorail",
             "de-DE": "Die Fahrgäste sitzen auf dem Rücken von Raptor-artigen Wagen auf einer Einschienen-Strecke.",
             "es-ES": "Los usuarios se sientan en vehículos con forma de velocirraptor, en un circuito monorraíl.",

--- a/objects/rct2tt/ride/rct2.tt.rivrstyx.json
+++ b/objects/rct2tt/ride/rct2.tt.rivrstyx.json
@@ -58,7 +58,7 @@
             "ru-RU": "Стикс"
         },
         "description": {
-            "en-GB": "Boats gently meander around a river track",
+            "en-GB": "Boats built for flat river tracks with an Underworld theme",
             "fr-FR": "Des bateaux en forme de radeau descendent paisiblement une voie navigable",
             "de-DE": "Wildwasserboote gleiten einen Flusslauf entlang.",
             "es-ES": "Botes con forma de balsa que serpentean tranquilamente por un circuito de río.",

--- a/objects/rct2tt/ride/rct2.tt.rivrstyx.json
+++ b/objects/rct2tt/ride/rct2.tt.rivrstyx.json
@@ -58,7 +58,7 @@
             "ru-RU": "Стикс"
         },
         "description": {
-            "en-GB": "Boats built for flat river tracks with an Underworld theme",
+            "en-GB": "Boats with an Underworld theme, built for flat river tracks",
             "fr-FR": "Des bateaux en forme de radeau descendent paisiblement une voie navigable",
             "de-DE": "Wildwasserboote gleiten einen Flusslauf entlang.",
             "es-ES": "Botes con forma de balsa que serpentean tranquilamente por un circuito de río.",

--- a/objects/rct2tt/ride/rct2.tt.seaplane.json
+++ b/objects/rct2tt/ride/rct2.tt.seaplane.json
@@ -64,7 +64,7 @@
             "ru-RU": "Акваплан"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of cars able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
             "fr-FR": "Train suspendu à des montagnes russes et dont les voitures se balancent dans les virages",
             "de-DE": "Ein aufgehängter Achterbahnzug mit Wagen, die frei schwingen, wenn der Zug durch die Kurven fährt",
             "es-ES": "Tren de montaña rusa suspendido consistente en vagones capaces de girar con libertad cuando el tren coge curvas.",

--- a/objects/rct2tt/ride/rct2.tt.telepter.json
+++ b/objects/rct2tt/ride/rct2.tt.telepter.json
@@ -140,7 +140,7 @@
             "ru-RU": "Лифт"
         },
         "description": {
-            "en-GB": "Guests are transported up or down from one level to another",
+            "en-GB": "Futuristic lift cabin that gives guests the illusion of teleportation",
             "fr-FR": "Les visiteurs sont transportés vers le haut ou le bas d'un niveau à l'autre",
             "de-DE": "Die Gäste werden von einem Niveau zum anderen hinauf- oder hinuntertransportiert.",
             "es-ES": "Los invitados son transportados arriba y abajo, de un nivel a otro.",

--- a/objects/rct2tt/ride/rct2.tt.tricatop.json
+++ b/objects/rct2tt/ride/rct2.tt.tricatop.json
@@ -47,6 +47,7 @@
     "strings": {
         "name": {
             "en-GB": "Triceratops Dodgems",
+            "en-US": "Triceratops Bumper Cars",
             "fr-FR": "Auto-tamponneuses tricératops",
             "de-DE": "Triceratops-Autoskooter-Wagen",
             "es-ES": "Coches de choque Triceratops",
@@ -61,7 +62,8 @@
             "ru-RU": "Трицерапторы"
         },
         "description": {
-            "en-GB": "Riders lock horns with each other in triceratops dodgem cars",
+            "en-GB": "Riders lock horns with each other in triceratops dodgems",
+            "en-US": "Riders lock horns with each other in triceratops bumper cars",
             "fr-FR": "Les passagers se rentrent dedans à bord d'auto-tamponneuses en forme de tricératops",
             "de-DE": "Die Fahrer liefern sich beim Autoskooter harte Gefechte in Triceratops-Wagen.",
             "es-ES": "Los usuarios se pegan cornadas en los coches de choque Triceratops.",

--- a/objects/rct2tt/ride/rct2.tt.trilobte.json
+++ b/objects/rct2tt/ride/rct2.tt.trilobte.json
@@ -84,7 +84,7 @@
             "ru-RU": "Трилобиты"
         },
         "description": {
-            "en-GB": "Trilobite shaped cars run on roller coaster track to allow twisting curves and steep drops, splashing down into sections of water for gentle river sections",
+            "en-GB": "Trilobite-shaped roller coaster cars",
             "fr-FR": "Les voitures en forme de trilobites dévalent une voie en zigzag qui descend à toute vitesse dans l'eau, éclaboussant allègrement les passagers avant de traverser des passages en eau calme",
             "de-DE": "Die Wagen in Form von Trilobiten fahren auf einer kurvenreichen Achterbahnstrecke mit steilem Gefälle, Wasserspektakel und sanften Flussabschnitten.",
             "es-ES": "Los vagones con forma de trilobite se desplazan por una montaña rusa de giros cerrados y pronunciadas caídas, pasando por zonas de agua de un río tranquilo.",

--- a/objects/rct2tt/ride/rct2.tt.valkyrie.json
+++ b/objects/rct2tt/ride/rct2.tt.valkyrie.json
@@ -63,7 +63,7 @@
             "ru-RU": "Валькирии"
         },
         "description": {
-            "en-GB": "Extra-wide cars descend completely vertical sloped track for the ultimate freefall roller coaster experience",
+            "en-GB": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
             "fr-FR": "Des voitures très larges descendent des voies en pente verticale. Pour amateurs de chute libre",
             "de-DE": "Die extrabreiten Wagen fahren ein senkrechtes Gefälle hinab und bieten die ultimative Erfahrung des freien Falls.",
             "es-ES": "Coches especialmente anchos que descienden verticalmente en la experiencia de caída libre definitiva.",

--- a/objects/rct2ww/ride/rct2.ww.bomerang.json
+++ b/objects/rct2ww/ride/rct2.ww.bomerang.json
@@ -88,7 +88,7 @@
             "ru-RU": "Бумеранг"
         },
         "description": {
-            "en-GB": "After an exhilarating air-powered launch, the train speeds up a vertical track, over the top, and vertically down the other side to return to the station",
+            "en-GB": "Air-powered launched roller coaster trains in the shape of boomerangs",
             "fr-FR": "Après avoir été propulsé dans les airs, le train accélère sur une voie verticale, passe le sommet, et retombe de l'autre côté en direction de la station",
             "de-DE": "Nach einem atemberaubenden Luftdruck-Start schnellt der Zug eine vertikale Strecke hoch, saust über die Spitze und auf der anderen Seite vertikal nach unten zurück zur Station",
             "es-ES": "Después de un emocionante lanzamiento propulsado por aire, el tren acelera por una vía vertical, pasa sobre la cima, y luego desciende verticalmente por el otro lado para volver a la estación",

--- a/objects/rct2ww/ride/rct2.ww.caddilac.json
+++ b/objects/rct2ww/ride/rct2.ww.caddilac.json
@@ -121,7 +121,7 @@
             "pt-BR": "Montanha-russa Limusine"
         },
         "description": {
-            "en-GB": "Limousine themed roller coaster cars",
+            "en-GB": "Limousine-themed roller coaster cars",
             "fr-FR": "Montagnes russes avec voitures en forme de limousine",
             "de-DE": "Achterbahn mit Wagen im Limousinenstil",
             "es-ES": "Montaña rusa con vagones inspirados en las limusinas",

--- a/objects/rct2ww/ride/rct2.ww.condorrd.json
+++ b/objects/rct2ww/ride/rct2.ww.condorrd.json
@@ -103,7 +103,7 @@
             "zh-TW": "神鷹暢遊"
         },
         "description": {
-            "en-GB": "Riding in special harnesses below the track, riders experience the feeling of flight as they swoop through the air in condor-shaped trains",
+            "en-GB": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
             "fr-FR": "Les passagers sont couchés à plat ventre dans une voiture en forme de condor se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
             "de-DE": "Die Passagiere fahren, in speziellen Gurten hängend, unterhalb der Strecke. In den kondorförmigen Wagen erleben sie dabei ein Gefühl des Fliegens.",
             "es-ES": "Los pasajeros viajan boca abajo y acostados, suspendidos del arnés debajo de la pista en un vagón con forma de Cóndor que se balancea libremente de un lado a otro al pasar por las curvas.",

--- a/objects/rct2ww/ride/rct2.ww.crocflum.json
+++ b/objects/rct2ww/ride/rct2.ww.crocflum.json
@@ -79,7 +79,7 @@
             "ru-RU": "Крокодил"
         },
         "description": {
-            "en-GB": "Crocodile-shaped boats travel along a water channel, splashing down steep slopes to soak the riders",
+            "en-GB": "Crocodile-shaped boats built for running in water channels",
             "fr-FR": "Bateaux en forme de crocodiles parcourant un tube aquatique dont les pentes abruptes auront pour effet de tremper les passagers",
             "de-DE": "Krokodilförmige Boote fahren in einem Wasserkanal und rutschen steile Gefälle herunter, damit die Fahrgäste nass werden",
             "es-ES": "Botes con forma de cocodrilo viajan por un canal de agua, salpicando por las empinadas cuestas de descenso para empapar a sus ocupantes",

--- a/objects/rct2ww/ride/rct2.ww.dhowwatr.json
+++ b/objects/rct2ww/ride/rct2.ww.dhowwatr.json
@@ -56,7 +56,7 @@
             "ru-RU": "Кораблик"
         },
         "description": {
-            "en-GB": "Decorative fishing boat, which the passengers paddle themselves",
+            "en-GB": "Decorative fishing boats, which the passengers paddle themselves",
             "fr-FR": "Bateau de pêche décoratif, propulsé par les passagers à l'aide de pagaies",
             "de-DE": "Dekoratives Fischerboot, das die Fahrgäste selbst durch Paddeln bewegen",
             "es-ES": "Bote de pesca decorativo en el que los pasajeros pedalean",

--- a/objects/rct2ww/ride/rct2.ww.dragdodg.json
+++ b/objects/rct2ww/ride/rct2.ww.dragdodg.json
@@ -54,7 +54,8 @@
             "pt-BR": "Cabeça de Dragão Chinês"
         },
         "description": {
-            "en-GB": "Riders battle each other in dragonhead-shaped cars",
+            "en-GB": "Self-drive electric dodgems",
+            "en-US": "Self-driven electric bumper cars",
             "fr-FR": "Auto-tamponneuses électriques programmées",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos autopropulsados",

--- a/objects/rct2ww/ride/rct2.ww.dragdodg.json
+++ b/objects/rct2ww/ride/rct2.ww.dragdodg.json
@@ -54,7 +54,7 @@
             "pt-BR": "Cabeça de Dragão Chinês"
         },
         "description": {
-            "en-GB": "Self-drive electric dodgem cars",
+            "en-GB": "Riders battle each other in dragonhead-shaped cars",
             "fr-FR": "Auto-tamponneuses électriques programmées",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos autopropulsados",

--- a/objects/rct2ww/ride/rct2.ww.football.json
+++ b/objects/rct2ww/ride/rct2.ww.football.json
@@ -66,8 +66,8 @@
             "ru-RU": "Футбол"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of football-shaped cars able to swing freely as the train goes around corners",
-            "en-US": "Suspended roller coaster train consisting of soccer ball-shaped cars able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+            "en-US": "Suspended roller coaster trains consisting of soccer ball-shaped cars able to swing freely as the train goes around corners",
             "fr-FR": "Train de montagnes russes suspendu constitué de voitures en forme de ballon de football qui se balancent librement dans les virages",
             "de-DE": "Hängender Achterbahnzug mit Wagen, die Fußbällen nachempfunden sind und in Kurven frei schwingen können",
             "es-ES": "Tren suspendido consistente en vagones con forma de balón de fútbol, los cuales se balancean libremente al tomar las curvas",

--- a/objects/rct2ww/ride/rct2.ww.gorilla.json
+++ b/objects/rct2ww/ride/rct2.ww.gorilla.json
@@ -65,7 +65,7 @@
             "ru-RU": "Горилла"
         },
         "description": {
-            "en-GB": "Suspended roller coaster train consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+            "en-GB": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
             "fr-FR": "Train de montagnes russes suspendu constitué de voitures en forme de gorille qui se balancent librement dans les virages",
             "de-DE": "Aufgehängter Achterbahnzug, dessen gorillaförmige Wagen frei schwingen können, wenn der Zug in die Kurven geht",
             "es-ES": "Tren en suspensión consistentes en vagones con forma de gorila capaces de balancearse con libertad al tomar las esquinas",

--- a/objects/rct2ww/ride/rct2.ww.hipporid.json
+++ b/objects/rct2ww/ride/rct2.ww.hipporid.json
@@ -60,7 +60,7 @@
             "ru-RU": "Гиппопотам"
         },
         "description": {
-            "en-GB": "Riders ride in a submerged submarine through an underwater course",
+            "en-GB": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
             "fr-FR": "Les passagers sont dans un sous-marin immergé suivant un itinéraire",
             "de-DE": "Die Fahrgäste fahren in einem U-Boot auf einer Unterwasserstrecke",
             "es-ES": "Los pasajeros montan en un submarino sumergido que viaja por una ruta submarina",

--- a/objects/rct2ww/ride/rct2.ww.huskie.json
+++ b/objects/rct2ww/ride/rct2.ww.huskie.json
@@ -78,7 +78,7 @@
             "pt-BR": "Carro Huskie Siberiano"
         },
         "description": {
-            "en-GB": "Powered vehicles in the shape of Huskie sleds which follow a track-based route",
+            "en-GB": "Powered vehicles in the shape of Huskie sleds",
             "fr-FR": "Véhicules en forme de traîneaux suivant un itinéraire sur piste",
             "de-DE": "Huskyschlittenförmige Fahrzeuge mit Eigenantrieb, die einer Schienenstrecke folgen",
             "es-ES": "Vehículos eléctricos con forma de trineos de perros huskies, que siguen una ruta sobre raíles",

--- a/objects/rct2ww/ride/rct2.ww.killwhal.json
+++ b/objects/rct2ww/ride/rct2.ww.killwhal.json
@@ -60,7 +60,7 @@
             "ru-RU": "Кит-Убийца"
         },
         "description": {
-            "en-GB": "Riders ride in a submerged submarine through an underwater course",
+            "en-GB": "Riders ride in a submerged whale-shaped submarine through an underwater course",
             "fr-FR": "Les passagers sont dans un sous-marin immergé suivant un itinéraire",
             "de-DE": "Die Fahrgäste fahren in einem U-Boot auf einer Unterwasserstrecke",
             "es-ES": "Los pasajeros montan en un submarino sumergido que viaja por una ruta submarina",

--- a/objects/rct2ww/ride/rct2.ww.mandarin.json
+++ b/objects/rct2ww/ride/rct2.ww.mandarin.json
@@ -65,7 +65,7 @@
             "ru-RU": "Мандариновая утка"
         },
         "description": {
-            "en-GB": "Duck-shaped boat, propelled by the pedalling front seat passengers",
+            "en-GB": "Duck-shaped boats, propelled by the pedalling front seat passengers",
             "fr-FR": "Bateau en forme de cygne, propulsé par les passagers avant à l'aide d'un pédalier",
             "de-DE": "Ein schwanenförmiges Boot, das von den Fahrgästen auf den Vordersitzen angetrieben wird, die selber in die Pedale treten müssen",
             "es-ES": "Bote con forma de cisne, impulsado por el pedaleo de los pasajeros del asiento delantero",

--- a/objects/rct2ww/ride/rct2.ww.penguinb.json
+++ b/objects/rct2ww/ride/rct2.ww.penguinb.json
@@ -60,7 +60,7 @@
             "ru-RU": "Пингвин-Бобслей"
         },
         "description": {
-            "en-GB": "Riders career down a twisting track in penguin-shaped cars guided only by the curvature and banking of the semi-circular track",
+            "en-GB": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
             "fr-FR": "Les passagers suivent un tracé sinueux dans des voitures en forme de pingouin, dirigés uniquement par la courbure et l'inclinaison semi-circulaire de la piste",
             "de-DE": "Die Fahrgäste schlittern in pinguinförmigen Wagen eine Zickzackbahn hinunter, wobei sie nur durch die Kurvenführung und den Neigungswinkel der Strecke geführt werden",
             "es-ES": "Los pasajeros viajan por unas vías retorcidas en vagones con forma de pingüino guiados únicamente por la curvatura y los peraltes de la vía semicircular",

--- a/objects/rct2ww/ride/rct2.ww.polarber.json
+++ b/objects/rct2ww/ride/rct2.ww.polarber.json
@@ -72,7 +72,7 @@
             "ru-RU": "Белый медведь"
         },
         "description": {
-            "en-GB": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+            "en-GB": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
             "fr-FR": "Les passagers, alignés par deux, peuvent regarder en avant ou en arrière en effectuant boucles et inversions",
             "de-DE": "Die Fahrgäste sitzen paarweise und blicken mal nach vorne, mal nach hinten, während sie auf einer kurvigen Strecke im Zickzack fahren",
             "es-ES": "Los pasajeros se sientan en parejas mirando atrás o adelante y atraviesan ceñidas inversiones que giran y se retuercen",

--- a/objects/rct2ww/ride/rct2.ww.rocket.json
+++ b/objects/rct2ww/ride/rct2.ww.rocket.json
@@ -65,7 +65,7 @@
             "ru-RU": "Ракета 1950"
         },
         "description": {
-            "en-GB": "Inverted roller coaster trains are accelerated out of the station to travel up a vertical spike of track, then reverse back through the station to travel backwards up another vertical spike of track",
+            "en-GB": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
             "fr-FR": "Les trains de montagnes russes inversées sont propulsés hors de la station puis, après avoir atteint une pointe verticale, redescendent vers la station et entament une nouvelle montée verticale en sens inverse",
             "de-DE": "Umgekehrte Achterbahnzüge werden aus der Station heraus auf einer vertikalen Strecke beschleunigt und kommen zurück zur Station, von wo sie rückwärts eine andere vertikale Strecke hinaufgeschossen werden",
             "es-ES": "Trenes invertidos que aceleran al salir de la estación para subir por un tramo vertical de la vía, luego retroceden de vuelta a través de la estación para viajar hacia atrás y subir por otra vía vertical",

--- a/objects/rct2ww/ride/rct2.ww.skidoo.json
+++ b/objects/rct2ww/ride/rct2.ww.skidoo.json
@@ -40,6 +40,7 @@
     "strings": {
         "name": {
             "en-GB": "Skidoo Dodgems",
+            "en-US": "Skidoo Bumper Cars",
             "fr-FR": "Motoneiges tamponneuses",
             "de-DE": "Schlitterskooter",
             "es-ES": "Coches de choque esquimales",
@@ -54,7 +55,7 @@
             "pt-BR": "Carro Esquimó"
         },
         "description": {
-            "en-GB": "Self-drive electric dodgem cars",
+            "en-GB": "Riders slide around in small skidoo-shaped vehicles that they freely control",
             "fr-FR": "Auto-tamponneuses électriques programmées",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos de conducción propia",

--- a/objects/rct2ww/ride/rct2.ww.skidoo.json
+++ b/objects/rct2ww/ride/rct2.ww.skidoo.json
@@ -55,7 +55,8 @@
             "pt-BR": "Carro Esquimó"
         },
         "description": {
-            "en-GB": "Riders slide around in small skidoo-shaped vehicles that they freely control",
+            "en-GB": "Self-drive skidoo-shaped dodgems",
+            "en-US": "Self-driven skidoo-shaped bumper cars",
             "fr-FR": "Auto-tamponneuses électriques programmées",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos de conducción propia",

--- a/objects/rct2ww/ride/rct2.ww.sputnikr.json
+++ b/objects/rct2ww/ride/rct2.ww.sputnikr.json
@@ -58,7 +58,7 @@
             "ru-RU": "Спутник"
         },
         "description": {
-            "en-GB": "Suspended satellite-shaped cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+            "en-GB": "Russian satellite-shaped cars which swing from the rail above",
             "fr-FR": "Les passagers sont couchés à plat ventre dans une voiture spéciale se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
             "de-DE": "Die Passagiere fahren kopfüber liegend und hängen dabei in einem speziell entworfenen Wagen von einer Einschienenstrecke, wobei sie in den Kurven frei von Seite zu Seite schwingen",
             "es-ES": "Los pasajeros viajan boca abajo en posición tumbada, suspendidos del monorraíl en un vagón de diseño especial que se balancea libremente de un lado a otro al tomar las curvas",

--- a/objects/rct2ww/ride/rct2.ww.sputnikr.json
+++ b/objects/rct2ww/ride/rct2.ww.sputnikr.json
@@ -58,7 +58,7 @@
             "ru-RU": "Спутник"
         },
         "description": {
-            "en-GB": "Passengers ride face-down in a lying position, suspended in a specially designed car from the single-rail track, swinging freely from side to side around corners",
+            "en-GB": "Suspended satellite-shaped cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
             "fr-FR": "Les passagers sont couchés à plat ventre dans une voiture spéciale se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
             "de-DE": "Die Passagiere fahren kopfüber liegend und hängen dabei in einem speziell entworfenen Wagen von einer Einschienenstrecke, wobei sie in den Kurven frei von Seite zu Seite schwingen",
             "es-ES": "Los pasajeros viajan boca abajo en posición tumbada, suspendidos del monorraíl en un vagón de diseño especial que se balancea libremente de un lado a otro al tomar las curvas",

--- a/objects/rct2ww/ride/rct2.ww.surfbrdc.json
+++ b/objects/rct2ww/ride/rct2.ww.surfbrdc.json
@@ -108,7 +108,7 @@
             "ru-RU": "Серфинг Коастер"
         },
         "description": {
-            "en-GB": "Riders ride in a standing position in wide coaster trains with specially designed restraints as they race down smooth drops and through multiple inversions",
+            "en-GB": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
             "fr-FR": "Les passagers suivent un parcours jalonné de pentes régulières et de multiples inversions, debouts dans de grands trains disposant de protections spéciales",
             "de-DE": "Die Passagiere fahren stehend in breiten Zügen mit speziellen Halterungen durch sanfte Gefälle und mehrere Überkopfteile",
             "es-ES": "Los pasajeros viajan de pie en amplios trenes con sujeciones especialmente diseñadas, y recorren suaves caídas con múltiples inversiones",

--- a/objects/rct2ww/ride/rct2.ww.tgvtrain.json
+++ b/objects/rct2ww/ride/rct2.ww.tgvtrain.json
@@ -135,7 +135,7 @@
             "ru-RU": "Поезд TGV"
         },
         "description": {
-            "en-GB": "Roller coaster trains in the style of French high-speed trains (TGV) are accelerated out of the station by linear induction motors to speed through twisting inversions",
+            "en-GB": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
             "fr-FR": "Train de montagnes russes propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversions renversantes",
             "de-DE": "Achterbahnzüge werden mithilfe von Linearmotoren aus der Station heraus beschleunigt und rasen durch gewundene Überkopfteile",
             "es-ES": "Los trenes de la montaña rusa salen de la estación acelerados por unos motores de inducción para pasar a toda velocidad por unas retorcidas inversiones",


### PR DESCRIPTION
Here's a follow-up PR to the previous ride/vehicle description rework (#52).

This further refines the vehicle descriptions. This time, by simplifying them and moving the focus away from the track to the vehicle itself.
Many descriptions, especially for roller coaster trains, were still mostly a direct copy from the ride descriptions, and thus included many words about the track. As the vehicle descriptions appear in the vehicle tab of the ride window, descriptions of the track are redundant; the track is already described just fine in the Build Ride window.
The vehicle descriptions are changed in a way that they only describe features relevant to the vehicle, rather than the track. There are some exceptions, but even for those I tried to kept words about the track itself ot a minimum.

Other noteworthy changes:
* “dodgem cars” renamed to “dodgems”. I looked it up in dictionaries, and I think in UK the bumper cars are really just called “dodgems”, and not “dodgem cars”.
* Reworked descriptions for Dodgems and Flying Saucer and Go-Karts (and all their variants) to follow the same style. They are now written in a more generic way so that they make sense both as ride *and* vehicle description. <https://github.com/OpenRCT2/OpenRCT2/issues/10194> will be ALMOST fixed by this (still needs edit of `en-GB.txt` for the go-kart ride, expect a PR on OpenRCT2 repo soon)
* Various minor fixes, mostly grammar-related