### PR TITLE
Surfing Trains fixes

### DIFF
--- a/objects/rct2ww/ride/rct2.ww.surfbrdc.json
+++ b/objects/rct2ww/ride/rct2.ww.surfbrdc.json
@@ -108,7 +108,7 @@
             "ru-RU": "Серфинг Коастер"
         },
         "description": {
-            "en-GB": "A surfboard-themed train with shoulder restraints, in which the riders stand up",
+            "en-GB": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
             "fr-FR": "Les passagers suivent un parcours jalonné de pentes régulières et de multiples inversions, debouts dans de grands trains disposant de protections spéciales",
             "de-DE": "Die Passagiere fahren stehend in breiten Zügen mit speziellen Halterungen durch sanfte Gefälle und mehrere Überkopfteile",
             "es-ES": "Los pasajeros viajan de pie en amplios trenes con sujeciones especialmente diseñadas, y recorren suaves caídas con múltiples inversiones",

--- a/objects/rct2ww/ride/rct2.ww.surfbrdc.json
+++ b/objects/rct2ww/ride/rct2.ww.surfbrdc.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 4,
-        "maxCarsPerTrain": 7,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "tabCar": 1,
         "headCars": 1,
@@ -108,7 +108,7 @@
             "ru-RU": "Серфинг Коастер"
         },
         "description": {
-            "en-GB": "Riders ride in a standing position in wide coaster trains with specially designed restraints as they race down smooth drops and through multiple inversions",
+            "en-GB": "A surfboard-themed train with shoulder restraints, in which the riders stand up",
             "fr-FR": "Les passagers suivent un parcours jalonné de pentes régulières et de multiples inversions, debouts dans de grands trains disposant de protections spéciales",
             "de-DE": "Die Passagiere fahren stehend in breiten Zügen mit speziellen Halterungen durch sanfte Gefälle und mehrere Überkopfteile",
             "es-ES": "Los pasajeros viajan de pie en amplios trenes con sujeciones especialmente diseñadas, y recorren suaves caídas con múltiples inversiones",


### PR DESCRIPTION
I have made changes to the Surfing Trains:

- Increased maxCarsPerTrain from 7 to 9, for parity with the Twister Trains and Stand-up Twister Trains in RCT1 and OpenRCT2.
- Changed the English description to be more consistent with the Stand-up Twister Trains' new description.

This is part of my bigger project to fix the Wacky Worlds and Time Twister vehicles, either to better their descriptions (e.g. simplification, making the descriptions more specific), adding hasShelter flags, increasing the maxCarsPerTrain value to be more on par with these vehicles' base counterparts from RCT2 and RCT1, or a combination of the three.