### PR TITLE
Consistent writing style for dodgem-like / flying saucer-like rides

### DIFF
--- a/objects/rct2/ride/rct2.dodg1.json
+++ b/objects/rct2/ride/rct2.dodg1.json
@@ -66,8 +66,8 @@
             "ru-RU": "Кар"
         },
         "description": {
-            "en-GB": "Self-drive electric dodgems",
-            "en-US": "Self-driven electric bumper cars",
+            "en-GB": "Riders bump into each other in self-drive electric dodgems",
+            "en-US": "Riders bump into each other in self-driven electric bumper cars",
             "fr-FR": "Autos tamponneuses électriques",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos autopropulsados",

--- a/objects/rct2/ride/rct2.fsauc.json
+++ b/objects/rct2/ride/rct2.fsauc.json
@@ -57,8 +57,7 @@
             "ru-RU": "Тарелочки"
         },
         "description": {
-            "en-GB": "Self-drive saucer-shaped hovercraft vehicles",
-            "en-US": "Self-driven saucer-shaped hovercraft vehicles",
+            "en-GB": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
             "fr-FR": "Aéroglisseurs auto-guidés",
             "de-DE": "Selbstgesteuerte Luftkissenfahrzeuge",
             "es-ES": "Vehículos aerodeslizadores autopropulsados",

--- a/objects/rct2ww/ride/rct2.ww.dragdodg.json
+++ b/objects/rct2ww/ride/rct2.ww.dragdodg.json
@@ -54,8 +54,8 @@
             "pt-BR": "Cabeça de Dragão Chinês"
         },
         "description": {
-            "en-GB": "Self-drive electric dodgems",
-            "en-US": "Self-driven electric bumper cars",
+            "en-GB": "Guests battle each other in dragonhead-shaped dodgems",
+            "en-US": "Guests battle each other in dragonhead-shaped bumper cars",
             "fr-FR": "Auto-tamponneuses électriques programmées",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos autopropulsados",

--- a/objects/rct2ww/ride/rct2.ww.skidoo.json
+++ b/objects/rct2ww/ride/rct2.ww.skidoo.json
@@ -55,8 +55,7 @@
             "pt-BR": "Carro Esquimó"
         },
         "description": {
-            "en-GB": "Self-drive skidoo-shaped dodgems",
-            "en-US": "Self-driven skidoo-shaped bumper cars",
+            "en-GB": "Guests slide around in skidoo-shaped vehicles that they freely control",
             "fr-FR": "Auto-tamponneuses électriques programmées",
             "de-DE": "Selbstgesteuerte elektrische Autoskooter",
             "es-ES": "Coches de choque eléctricos de conducción propia",


### PR DESCRIPTION
Fixes <https://github.com/OpenRCT2/OpenRCT2/issues/10194>.

It changes descriptions of (in total 4) dodgem-style and flyingsacuer-style vehicles/rides to be a) more consistent with each other and b) are nicer (i.e. make more sense) for BOTH the vehicle window and the build ride window.

--------

Previous:

* **Dodgems**: Self-drive electric dodgems
* Fighting Knights Dodgems: Riders joust on horse-themed dodgems
* Triceratops Dodgems: Riders lock horns with each other in triceratops dodgems

* **Flying Saucers**: Self-drive saucer-shaped hovercraft vehicles
* **Chinese Dragonhead Ride**: Self-drive electric dodgems
* Flower Power Ride: Riders ride in flower-shaped hovercraft vehicles that they freely control
* **Skidoo Dodgems**: Self-drive skidoo-shaped dodgems
* Cyclops Ride: Riders ride the Eye of a Giant Cyclops

NEW:

* **Dodgems**: Riders bump into each other in self-drive electric dodgems
* Fighting Knights Dodgems: Riders joust on horse-themed dodgems
* Triceratops Dodgems: Riders lock horns with each other in triceratops dodgems

* **Flying Saucers**: Guests ride in saucer-shaped hovercraft vehicles that they freely control
* **Chinese Dragonhead Ride**: Guests battle each other in dragonhead-shaped dodgems
* Flower Power Ride: Riders ride in flower-shaped hovercraft vehicles that they freely control
* **Skidoo Dodgems**: Guests slide around in skidoo-shaped vehicles that they freely control
* Cyclops Ride: Riders ride the Eye of a Giant Cyclops

(Note: Only rides in bold have changed descriptions. The unchanged descriptions are only listed here for context.)

(Note 2: en-US is of course also in this PR.)