### PR TITLE
Improve language dump and load python scripts

### DIFF
--- a/language_dump.py
+++ b/language_dump.py
@@ -5,12 +5,16 @@ import glob
 import json
 # from pprint import pprint
 
+supported_languages = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES", "fi-FI",\
+                       "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL", "pl-PL", "pt-BR",\
+                       "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+
 # Command line arguments.
 parser = argparse.ArgumentParser(description='Dump translations for OpenRCT2\'s JSON objects.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-o', '--objects', default="objects", help='JSON objects directory')
-parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against')
+parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against', choices=supported_languages)
 parser.add_argument('-d', '--dumpfile', help='Translation file to export to', required=True)
-parser.add_argument('-l', '--language', help='Language that should be extracted, e.g. ja-JP', required=True)
+parser.add_argument('-l', '--language', help='Language that should be extracted, e.g. ja-JP', required=True, choices=supported_languages)
 args = parser.parse_args()
 
 language_to_extract = args.language

--- a/language_dump.py
+++ b/language_dump.py
@@ -20,7 +20,7 @@ dump_file_name = args.dumpfile
 strings_by_object = {}
 
 for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
-    with open(filename) as file:
+    with open(filename, encoding="utf8") as file:
         data = json.load(file)
 
         if not 'strings' in data:
@@ -41,7 +41,7 @@ for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
                 print("No existing translation for " + data['id'] + " yet, but no English string either -- skipping")
                 # pprint(data)
 
-out = open(dump_file_name, "w")
+out = open(dump_file_name, "w", encoding="utf8")
 json.dump(strings_by_object, out, indent=4, ensure_ascii=False, separators=(',', ': '))
 out.write("\n")
 out.close()

--- a/language_dump.py
+++ b/language_dump.py
@@ -15,11 +15,13 @@ parser.add_argument('-o', '--objects', default="objects", help='JSON objects dir
 parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against', choices=supported_languages)
 parser.add_argument('-d', '--dumpfile', help='Translation file to export to', required=True)
 parser.add_argument('-l', '--language', help='Language that should be extracted, e.g. ja-JP', required=True, choices=supported_languages)
+parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Maximize information printed on screen')
 args = parser.parse_args()
 
 language_to_extract = args.language
 fallback_language = args.fallback
 dump_file_name = args.dumpfile
+verbose = args.verbose
 
 strings_by_object = {}
 
@@ -36,13 +38,15 @@ for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
                 strings_by_object[data['id']] = {}
 
             if language_to_extract in data['strings'][string_key]:
-                print("Found existing translation for " + data['id'])
+                if verbose:
+                    print("Found existing translation for " + data['id'])
                 strings_by_object[data['id']][string_key] = data['strings'][string_key][language_to_extract]
             elif fallback_language in data['strings'][string_key]:
                 print("No existing translation for " + data['id'] + " yet, using English")
                 strings_by_object[data['id']][string_key] = data['strings'][string_key][fallback_language]
             else:
-                print("No existing translation for " + data['id'] + " yet, but no English string either -- skipping")
+                if verbose:
+                    print("No existing translation for " + data['id'] + " yet, but no English string either -- skipping")
                 # pprint(data)
 
 out = open(dump_file_name, "w", encoding="utf8")

--- a/language_load.py
+++ b/language_load.py
@@ -5,12 +5,16 @@ import glob
 import json
 import re
 
+supported_languages = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES", "fi-FI",\
+                       "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL", "pl-PL", "pt-BR",\
+                       "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+
 # Command line arguments.
 parser = argparse.ArgumentParser(description='Imports translations into OpenRCT2\'s JSON objects.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-o', '--objects', default="objects", help='JSON objects directory')
-parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against')
+parser.add_argument('-f', '--fallback', default="en-GB", help='Fallback language to check against', choices=supported_languages)
 parser.add_argument('-i', '--input', help='Translation dump file to import from', required=True)
-parser.add_argument('-l', '--language', help='Language that is being translated, e.g. ja-JP', required=True)
+parser.add_argument('-l', '--language', help='Language that is being translated, e.g. ja-JP', required=True, choices=supported_languages)
 args = parser.parse_args()
 
 language_to_import = args.language

--- a/language_load.py
+++ b/language_load.py
@@ -16,7 +16,7 @@ args = parser.parse_args()
 language_to_import = args.language
 fallback_language = args.fallback
 
-in_file = open(args.input)
+in_file = open(args.input, encoding="utf8")
 strings_by_object = json.load(in_file)
 in_file.close()
 
@@ -38,7 +38,7 @@ class LessVerboseJSONEncoder(json.JSONEncoder):
             yield s
 
 for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
-    file = open(filename)
+    file = open(filename, encoding="utf8")
     data = json.load(file)
     file.close()
 
@@ -80,7 +80,7 @@ for filename in glob.iglob(args.objects + '/**/*.json', recursive=True):
             updated = True
 
     if updated:
-        file = open(filename, "w")
+        file = open(filename, "w", encoding="utf8")
         json.dump(data, file, indent=4, separators=(',', ': '), ensure_ascii=False, cls=LessVerboseJSONEncoder)
         file.write("\n")
         file.close()


### PR DESCRIPTION
1. Specify encoding on language_dump.py I/O
2. Specify encoding on language_load.py I/O
3. Only allow languages listed in Localisation for language scripts
4. language_dump.py: Only dump on missing translations
5. language_load.py: Only print when a translation is updated

I think the commit titles are pretty self explanatory, but I'll explain the overall goal here.
- 1 and 2 fix problems I had while running the script.
- 3 makes it safer to run and paves the way for running it for all languages
- 4 and 5 make it more terminal friendly in case we're running for all languages.

This is a first building block for the project I called "Ease Objects Translation", which we discussed a week ago or so.