### PR TITLE
Allow language_dump.py to accept either a file or a dir

### DIFF
--- a/language_dump.py
+++ b/language_dump.py
@@ -6,11 +6,18 @@ Dump translations for OpenRCT2's JSON objects given a language and a file
 import argparse
 import glob
 import json
+import os
 # from pprint import pprint
 
 SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
                        "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
                        "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+
+def dir_path(string):
+    """ Checks for a valid dir_path """
+    if os.path.isdir(string):
+        return string
+    raise NotADirectoryError(string)
 
 def get_arg_parser():
     """ Command line arguments """
@@ -19,7 +26,10 @@ def get_arg_parser():
     parser.add_argument('-o', '--objects', default="objects", help='JSON objects directory')
     parser.add_argument('-f', '--fallback', default="en-GB",\
                         help='Fallback language to check against', choices=SUPPORTED_LANGUAGES)
-    parser.add_argument('-d', '--dumpfile', help='Translation file to export to', required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-t', '--target_dir', help='Directory to dump translation files',\
+                       type=dir_path)
+    group.add_argument('-d', '--dumpfile', help='Translation file to export to')
     parser.add_argument('-l', '--language', help='Language that should be extracted, e.g. ja-JP',\
                         required=True, choices=SUPPORTED_LANGUAGES)
     parser.add_argument('-v', '--verbose', action='store_true', default=False,\


### PR DESCRIPTION
~*This is in draft while #77 and #79 are not merged, as it builds on top of them*~

This allows the script to accept either a single file or a directory, the latter being useful when we try to import all the supported languages at once.