### PR TITLE
Clean up non-wall references to 'shōji'

### DIFF
--- a/objects/rct2ww/scenery_small/rct2.ww.rshogi1.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rshogi1.json
@@ -23,7 +23,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Roof",
-            "fr-FR": "Toit shogi",
+            "fr-FR": "Toit shōji",
             "de-DE": "Shōji-Dach",
             "es-ES": "Tejado Shōji",
             "it-IT": "Tetto di Shōji",

--- a/objects/rct2ww/scenery_small/rct2.ww.rshogi1.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rshogi1.json
@@ -22,12 +22,12 @@
     "images": ["$RCT2:OBJDATA/RSHOGI1.DAT[0..3]"],
     "strings": {
         "name": {
-            "en-GB": "Shōji Roof",
-            "fr-FR": "Toit shōji",
-            "de-DE": "Shōji-Dach",
+            "en-GB": "Japanese Roof",
+            "fr-FR": "Toit japonais",
+            "de-DE": "Japanisches Dach",
             "es-ES": "Tejado Shōji",
             "it-IT": "Tetto di Shōji",
-            "nl-NL": "Shōjidak",
+            "nl-NL": "Japans dak",
             "sv-SE": "Shōji-tak",
             "zh-CN": "障子屋顶",
             "ja-JP": "日本的な屋",

--- a/objects/rct2ww/scenery_small/rct2.ww.rshogi2.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rshogi2.json
@@ -23,7 +23,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Roof",
-            "fr-FR": "Toit shogi",
+            "fr-FR": "Toit shōji",
             "de-DE": "Shōji-Dach",
             "es-ES": "Tejado Shōji",
             "it-IT": "Tetto di Shōji",

--- a/objects/rct2ww/scenery_small/rct2.ww.rshogi2.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rshogi2.json
@@ -22,12 +22,12 @@
     "images": ["$RCT2:OBJDATA/RSHOGI2.DAT[0..3]"],
     "strings": {
         "name": {
-            "en-GB": "Shōji Roof",
-            "fr-FR": "Toit shōji",
-            "de-DE": "Shōji-Dach",
+            "en-GB": "Japanese Roof",
+            "fr-FR": "Toit japonais",
+            "de-DE": "Japanisches Dach",
             "es-ES": "Tejado Shōji",
             "it-IT": "Tetto di Shōji",
-            "nl-NL": "Shōjidak",
+            "nl-NL": "Japans dak",
             "sv-SE": "Shōji-tak",
             "zh-CN": "障子屋顶",
             "ja-JP": "日本的な屋",

--- a/objects/rct2ww/scenery_small/rct2.ww.rshogi3.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rshogi3.json
@@ -22,7 +22,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Roof",
-            "fr-FR": "Toit shogi",
+            "fr-FR": "Toit shōji",
             "de-DE": "Shōji-Dach",
             "es-ES": "Tejado Shōji",
             "it-IT": "Tetto di Shōji",

--- a/objects/rct2ww/scenery_small/rct2.ww.rshogi3.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rshogi3.json
@@ -21,12 +21,12 @@
     "images": ["$RCT2:OBJDATA/RSHOGI3.DAT[0..3]"],
     "strings": {
         "name": {
-            "en-GB": "Shōji Roof",
-            "fr-FR": "Toit shōji",
-            "de-DE": "Shōji-Dach",
+            "en-GB": "Japanese Roof",
+            "fr-FR": "Toit japonais",
+            "de-DE": "Japanisches Dach",
             "es-ES": "Tejado Shōji",
             "it-IT": "Tetto di Shōji",
-            "nl-NL": "Shōjidak",
+            "nl-NL": "Japans dak",
             "sv-SE": "Shōji-tak",
             "zh-CN": "障子屋顶",
             "ja-JP": "日本的な屋",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi01.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi01.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi02.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi02.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi03.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi03.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi04.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi04.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi05.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi05.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi06.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi06.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi07.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi07.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi08.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi08.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi09.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi09.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi10.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi10.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi11.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi11.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi12.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi12.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi13.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi13.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi14.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi14.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi15.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi15.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi15.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi15.json
@@ -13,12 +13,12 @@
     "images": ["$RCT2:OBJDATA/WSHOGI15.DAT[0..5]"],
     "strings": {
         "name": {
-            "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shōji",
-            "de-DE": "Shōji-Wand",
+            "en-GB": "Japanese Fence",
+            "fr-FR": "Clôture japonais",
+            "de-DE": "Japanischer Zaun",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",
-            "nl-NL": "Shōjiwand",
+            "nl-NL": "Japans hek",
             "sv-SE": "Shōji-mur",
             "zh-CN": "障子墙",
             "ja-JP": "日本的な垣",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi16.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi16.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi16.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi16.json
@@ -13,12 +13,12 @@
     "images": ["$RCT2:OBJDATA/WSHOGI16.DAT[0..5]"],
     "strings": {
         "name": {
-            "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shōji",
-            "de-DE": "Shōji-Wand",
+            "en-GB": "Japanese Fence",
+            "fr-FR": "Clôture japonais",
+            "de-DE": "Japanischer Zaun",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",
-            "nl-NL": "Shōjiwand",
+            "nl-NL": "Japans hek",
             "sv-SE": "Shōji-mur",
             "zh-CN": "障子墙",
             "ja-JP": "日本的な垣",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi17.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi17.json
@@ -14,7 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shogi",
+            "fr-FR": "Cloison shōji",
             "de-DE": "Shōji-Wand",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wshogi17.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wshogi17.json
@@ -13,12 +13,12 @@
     "images": ["$RCT2:OBJDATA/WSHOGI17.DAT[0..5]"],
     "strings": {
         "name": {
-            "en-GB": "Shōji Wall",
-            "fr-FR": "Cloison shōji",
-            "de-DE": "Shōji-Wand",
+            "en-GB": "Japanese Fence",
+            "fr-FR": "Clôture japonais",
+            "de-DE": "Japanischer Zaun",
             "es-ES": "Pared Shōji",
             "it-IT": "Muro di Shōji",
-            "nl-NL": "Shōjiwand",
+            "nl-NL": "Japans hek",
             "sv-SE": "Shōji-mur",
             "zh-CN": "障子墙",
             "ja-JP": "日本的な垣",


### PR DESCRIPTION
The shōji term only refers to the walls, not the roofs or fences. I therefore propose we fall back to this less-specific, but more accurate, terminology.