### PR TITLE
de-DE: Scenery grammar cleanup

### DIFF
--- a/objects/rct2/scenery_small/rct2.allsort1.json
+++ b/objects/rct2/scenery_small/rct2.allsort1.json
@@ -22,7 +22,7 @@
         "name": {
             "en-GB": "Candy",
             "fr-FR": "Bonbon",
-            "de-DE": "Bonbon",
+            "de-DE": "Süßigkeit",
             "es-ES": "Caramelo",
             "it-IT": "Dolce",
             "nl-NL": "Snoep",

--- a/objects/rct2/scenery_small/rct2.allsort2.json
+++ b/objects/rct2/scenery_small/rct2.allsort2.json
@@ -22,7 +22,7 @@
         "name": {
             "en-GB": "Candy",
             "fr-FR": "Bonbon",
-            "de-DE": "Bonbon",
+            "de-DE": "Süßigkeit",
             "es-ES": "Caramelo",
             "it-IT": "Dolce",
             "nl-NL": "Snoep",

--- a/objects/rct2/scenery_small/rct2.ball1.json
+++ b/objects/rct2/scenery_small/rct2.ball1.json
@@ -19,6 +19,7 @@
         "name": {
             "en-GB": "American Football",
             "fr-FR": "Football américain",
+            "de-DE": "American Football",
             "es-ES": "Fútbol americano",
             "it-IT": "Pallone da football americano",
             "nl-NL": "American football",

--- a/objects/rct2/scenery_small/rct2.ball2.json
+++ b/objects/rct2/scenery_small/rct2.ball2.json
@@ -19,6 +19,7 @@
         "name": {
             "en-GB": "American Football",
             "fr-FR": "Football américain",
+            "de-DE": "American Football",
             "es-ES": "Fútbol americano",
             "it-IT": "Pallone da football americano",
             "nl-NL": "American football",

--- a/objects/rct2/scenery_small/rct2.beanst1.json
+++ b/objects/rct2/scenery_small/rct2.beanst1.json
@@ -18,7 +18,7 @@
         "name": {
             "en-GB": "Giant Beanstalk",
             "fr-FR": "Haricot géant",
-            "de-DE": "Riesiger Bohnenstengel",
+            "de-DE": "Riesiger Bohnenstängel",
             "es-ES": "Pedúnculo de judías",
             "it-IT": "Pianta di fagiolo gigante",
             "nl-NL": "Gigantische bonenstaak",

--- a/objects/rct2/scenery_small/rct2.beanst2.json
+++ b/objects/rct2/scenery_small/rct2.beanst2.json
@@ -18,7 +18,7 @@
         "name": {
             "en-GB": "Giant Beanstalk",
             "fr-FR": "Haricot géant",
-            "de-DE": "Riesiger Bohnenstengel",
+            "de-DE": "Riesiger Bohnenstängel",
             "es-ES": "Pedúnculo de judías",
             "it-IT": "Pianta di fagiolo gigante",
             "nl-NL": "Gigantische bonenstaak",

--- a/objects/rct2/scenery_small/rct2.cndyrk1.json
+++ b/objects/rct2/scenery_small/rct2.cndyrk1.json
@@ -22,7 +22,7 @@
         "name": {
             "en-GB": "Candy Stick",
             "fr-FR": "Sucre d'orge",
-            "de-DE": "Lutscher",
+            "de-DE": "Zuckerstange",
             "es-ES": "Caramelo de palo",
             "it-IT": "Stecca di zucchero",
             "nl-NL": "Snoepreep",

--- a/objects/rct2/scenery_small/rct2.colagum.json
+++ b/objects/rct2/scenery_small/rct2.colagum.json
@@ -20,7 +20,7 @@
         "name": {
             "en-GB": "Cola Candy",
             "fr-FR": "Bonbon cola",
-            "de-DE": "Cola-Bonbon",
+            "de-DE": "Cola-Fruchtgummi",
             "es-ES": "Caramelo de cola",
             "it-IT": "Dolce alla cola",
             "nl-NL": "Colasnoep",

--- a/objects/rct2/scenery_small/rct2.jelbab1.json
+++ b/objects/rct2/scenery_small/rct2.jelbab1.json
@@ -21,6 +21,7 @@
         "name": {
             "en-GB": "Jelly Baby",
             "fr-FR": "Bonbon",
+            "de-DE": "Baby-Fruchtgummi",
             "es-ES": "Bebé de gelatina",
             "it-IT": "Bambino di gelatina",
             "nl-NL": "Snoepje",

--- a/objects/rct2/scenery_small/rct2.tas4.json
+++ b/objects/rct2/scenery_small/rct2.tas4.json
@@ -18,7 +18,7 @@
         "name": {
             "en-GB": "Candy",
             "fr-FR": "Bonbon",
-            "de-DE": "Süßigkeiten",
+            "de-DE": "Süßigkeit",
             "es-ES": "Caramelo",
             "it-IT": "Dolci",
             "nl-NL": "Snoep",

--- a/objects/rct2/scenery_small/rct2.ttg.json
+++ b/objects/rct2/scenery_small/rct2.ttg.json
@@ -19,7 +19,7 @@
         "name": {
             "en-GB": "Target",
             "fr-FR": "Cible",
-            "de-DE": "Ziel",
+            "de-DE": "Zielscheibe",
             "es-ES": "Objetivo",
             "it-IT": "Obiettivo",
             "nl-NL": "Schietschijf",

--- a/objects/rct2/scenery_wall/rct2.wew.json
+++ b/objects/rct2/scenery_wall/rct2.wew.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Egyptian Wall",
             "fr-FR": "Mur égyptien",
-            "de-DE": "Ägyptische Wand",
+            "de-DE": "Ägyptische Mauer",
             "es-ES": "Pared egipcia",
             "it-IT": "Muro egiziano",
             "nl-NL": "Egyptische muur",

--- a/objects/rct2tt/scenery_large/rct2.tt.alnstr08.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.alnstr08.json
@@ -46,7 +46,7 @@
         "name": {
             "en-GB": "Alien Structure Large",
             "fr-FR": "Grande structure extraterrestre",
-            "de-DE": "Außerirdische Struktur Groß",
+            "de-DE": "Außerirdisches Gebäude, groß",
             "es-ES": "Estructura alienígena grande",
             "it-IT": "Grande struttura aliena",
             "nl-NL": "Grote Buitenaardse Constructie",

--- a/objects/rct2tt/scenery_large/rct2.tt.alnstr09.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.alnstr09.json
@@ -81,7 +81,7 @@
         "name": {
             "en-GB": "Alien Structure Large",
             "fr-FR": "Grande structure extraterrestre",
-            "de-DE": "Außerirdische Struktur Groß",
+            "de-DE": "Außerirdisches Gebäude, groß",
             "es-ES": "Estructura alienígena grande",
             "it-IT": "Grande struttura aliena",
             "nl-NL": "Grote Buitenaardse Constructie",

--- a/objects/rct2tt/scenery_large/rct2.tt.alnstr10.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.alnstr10.json
@@ -81,7 +81,7 @@
         "name": {
             "en-GB": "Alien Structure Large",
             "fr-FR": "Grande structure extraterrestre",
-            "de-DE": "Außerirdische Struktur Groß",
+            "de-DE": "Außerirdisches Gebäude, groß",
             "es-ES": "Estructura alienígena grande",
             "it-IT": "Grande struttura aliena",
             "nl-NL": "Grote Buitenaardse Constructie",

--- a/objects/rct2tt/scenery_large/rct2.tt.alnstr11.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.alnstr11.json
@@ -130,7 +130,7 @@
         "name": {
             "en-GB": "Alien Skylight Large",
             "fr-FR": "Grand voyant lumineux extraterrestre",
-            "de-DE": "Außerirdisches Oberlicht Groß",
+            "de-DE": "Außerirdisches Oberlicht, groß",
             "es-ES": "Claraboya alienígena grande",
             "it-IT": "Grande lucernario alieno",
             "nl-NL": "Groot Buitenaards Bovenlicht",

--- a/objects/rct2tt/scenery_large/rct2.tt.artdec25.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.artdec25.json
@@ -42,7 +42,7 @@
         "name": {
             "en-GB": "Art Deco Corner with Windows",
             "fr-FR": "Virage art déco avec fenêtres",
-            "de-DE": "Art Déco Ecke mit Fenstern",
+            "de-DE": "Art Déco - Ecke mit Fenstern",
             "es-ES": "Esquina Art Decó con ventanas",
             "it-IT": "Curva in art decò con finestre",
             "nl-NL": "Bocht met vensters Art Deco",

--- a/objects/rct2tt/scenery_large/rct2.tt.artdec26.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.artdec26.json
@@ -42,7 +42,7 @@
         "name": {
             "en-GB": "Art Deco Corner with Railings",
             "fr-FR": "Virage art déco avec grille",
-            "de-DE": "Art Déco Ecke mit Geländer",
+            "de-DE": "Art Déco - Ecke mit Geländer",
             "es-ES": "Esquina Art Decó con balaustrada",
             "it-IT": "Curva in art decò con ringhiere",
             "nl-NL": "Bocht met railing Art Deco",

--- a/objects/rct2tt/scenery_large/rct2.tt.artdec27.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.artdec27.json
@@ -44,7 +44,7 @@
         "name": {
             "en-GB": "Art Deco Top Corner Section",
             "fr-FR": "Section de virage haut art déco",
-            "de-DE": "Art Déco oberer Eckabschnitt",
+            "de-DE": "Art Déco - oberer Eckabschnitt",
             "es-ES": "Sección superior de esquina Art Decó",
             "it-IT": "Sezione di curva superiore in art decò",
             "nl-NL": "Bovenbochtstuk Art Deco",

--- a/objects/rct2tt/scenery_large/rct2.tt.forbidft.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.forbidft.json
@@ -48,7 +48,7 @@
         "name": {
             "en-GB": "Forbidden Fruit Tree",
             "fr-FR": "L'arbre du fruit défendu",
-            "de-DE": "Verbotener Obstbaum",
+            "de-DE": "Baum der verbotenen Früchte",
             "es-ES": "Árbol del fruto prohibido",
             "it-IT": "Albero del frutto proibito",
             "nl-NL": "Boom verboden vrucht",

--- a/objects/rct2tt/scenery_large/rct2.tt.futsky28.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.futsky28.json
@@ -72,7 +72,7 @@
         "name": {
             "en-GB": "Sandstone Walkway T-Junction",
             "fr-FR": "Jonction en T de la passerelle",
-            "de-DE": "Sandstein-Spazierweg T-Verbindung",
+            "de-DE": "Sandstein-Spazierweg-Gabelung",
             "es-ES": "Cruce en T de pasaje de arenisca",
             "it-IT": "Giunzione a T del viale in arenaria",
             "nl-NL": "T-splitsing Zandstenen Looppad",

--- a/objects/rct2tt/scenery_large/rct2.tt.futsky30.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.futsky30.json
@@ -72,7 +72,7 @@
         "name": {
             "en-GB": "Sandstone Walkway Corner",
             "fr-FR": "Virage de la passerelle",
-            "de-DE": "Sandstein-Spazierweg Ecke",
+            "de-DE": "Sandstein-Spazierweg-Ecke",
             "es-ES": "Esquina de pasaje de arenisca",
             "it-IT": "Curva del viale in arenaria",
             "nl-NL": "Bocht Zandstenen Looppad",

--- a/objects/rct2tt/scenery_large/rct2.tt.futsky31.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.futsky31.json
@@ -72,7 +72,7 @@
         "name": {
             "en-GB": "Sandstone Walkway Cross Section",
             "fr-FR": "Croisement de la passerelle",
-            "de-DE": "Sandstein-Spazierweg Kreuzung",
+            "de-DE": "Sandstein-Spazierweg-Kreuzung",
             "es-ES": "Sección de cruce de pasaje de arenisca",
             "it-IT": "Sezione trasversale del viale in arenaria",
             "nl-NL": "Kruising Zandstenen Looppad",

--- a/objects/rct2tt/scenery_large/rct2.tt.futsky32.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.futsky32.json
@@ -72,7 +72,7 @@
         "name": {
             "en-GB": "Sandstone Walkway End Section",
             "fr-FR": "Section finale de la passerelle",
-            "de-DE": "Sandstein-Spazierweg Endabschnitt",
+            "de-DE": "Sandstein-Spazierweg-Endabschnitt",
             "es-ES": "Sección final de pasaje de arenisca",
             "it-IT": "Sezione finale del viale in arenaria",
             "nl-NL": "Eindstuk Zandstenen Looppad",

--- a/objects/rct2tt/scenery_large/rct2.tt.histfix1.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.histfix1.json
@@ -130,7 +130,7 @@
         "name": {
             "en-GB": "Alien Historical Structures",
             "fr-FR": "Vestiges extraterrestres",
-            "de-DE": "Außerirdische Historische Strukturen",
+            "de-DE": "Außerirdische historische Gebäude",
             "es-ES": "Estructuras históricas alienígenas",
             "it-IT": "Strutture storiche degli alieni",
             "nl-NL": "Vreemde Historische Bouwsels",

--- a/objects/rct2tt/scenery_large/rct2.tt.histfix2.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.histfix2.json
@@ -46,7 +46,7 @@
         "name": {
             "en-GB": "Alien Historical Structures",
             "fr-FR": "Vestiges extraterrestres",
-            "de-DE": "Außerirdische Historische Strukturen",
+            "de-DE": "Außerirdische historische Gebäude",
             "es-ES": "Estructuras históricas alienígenas",
             "it-IT": "Strutture storiche degli alieni",
             "nl-NL": "Vreemde Historische Bouwsels",

--- a/objects/rct2tt/scenery_large/rct2.tt.hrbwal07.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.hrbwal07.json
@@ -42,7 +42,7 @@
         "name": {
             "en-GB": "Harbour Wall Corner Piece",
             "fr-FR": "Section de virage du mur du port",
-            "de-DE": "Hafenmauer Eckstück",
+            "de-DE": "Hafenmauer-Eckstück",
             "es-ES": "Sección de esquina de muro del puerto",
             "it-IT": "Tratto di curva del muro del porto",
             "nl-NL": "Havenmuur bochtstuk",

--- a/objects/rct2tt/scenery_large/rct2.tt.hrbwal08.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.hrbwal08.json
@@ -42,7 +42,7 @@
         "name": {
             "en-GB": "Harbour Wall Corner Piece",
             "fr-FR": "Section de virage du mur du port",
-            "de-DE": "Hafenmauer Eckstück",
+            "de-DE": "Hafenmauer-Eckstück",
             "es-ES": "Sección de esquina de muro del puerto",
             "it-IT": "Tratto di curva del muro del porto",
             "nl-NL": "Havenmuur bochtstuk",

--- a/objects/rct2tt/scenery_large/rct2.tt.psntwl26.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.psntwl26.json
@@ -32,7 +32,7 @@
         "name": {
             "en-GB": "Dark Age Village Roof Piece",
             "fr-FR": "Section de toit du village médiéval",
-            "de-DE": "Dachstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dachstück",
             "es-ES": "Sección de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto del villaggio dell'Età Oscura",
             "nl-NL": "Dakstuk middeleeuws dorp",

--- a/objects/rct2tt/scenery_large/rct2.tt.psntwl27.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.psntwl27.json
@@ -44,7 +44,7 @@
         "name": {
             "en-GB": "Dark Age Village Corner Roof Piece",
             "fr-FR": "Section de toit du virage du village médiéval",
-            "de-DE": "Dacheckstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dacheckstück",
             "es-ES": "Sección de esquina de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto in curva del villaggio dell'Età Oscura",
             "nl-NL": "Bochtstuk dak middeleeuws dorp",

--- a/objects/rct2tt/scenery_large/rct2.tt.psntwl28.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.psntwl28.json
@@ -44,7 +44,7 @@
         "name": {
             "en-GB": "Dark Age Village Inverted Roof Piece",
             "fr-FR": "Section de toit inversé du village médiéval",
-            "de-DE": "Umgedrehtes Dachstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Umgedrehtes Dachstück",
             "es-ES": "Sección inversa de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto invertito del villaggio dell'Età Oscura",
             "nl-NL": "Omgekeerd dakstuk middeleeuws dorp",

--- a/objects/rct2tt/scenery_large/rct2.tt.rdmet2x2.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.rdmet2x2.json
@@ -46,7 +46,7 @@
         "name": {
             "en-GB": "Small Red Meteor Crater",
             "fr-FR": "Petit cratère météoritique rouge",
-            "de-DE": "Kleiner Roter Meteoritenkrater",
+            "de-DE": "Kleiner roter Meteoritenkrater",
             "es-ES": "Cráter pequeño de meteorito rojo",
             "it-IT": "Piccolo cratere meteoritico rosso",
             "nl-NL": "Kleine rode meteoorkrater",

--- a/objects/rct2tt/scenery_large/rct2.tt.rdmet4x4.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.rdmet4x4.json
@@ -130,7 +130,7 @@
         "name": {
             "en-GB": "Large Red Meteor Crater",
             "fr-FR": "Grand cratère météoritique rouge",
-            "de-DE": "Großer Roter Meteoritenkrater",
+            "de-DE": "Großer roter Meteoritenkrater",
             "es-ES": "Cráter grande de meteorito rojo",
             "it-IT": "Grande cratere meteoritico rosso",
             "nl-NL": "Grote rode meteoorkrater",

--- a/objects/rct2tt/scenery_large/rct2.tt.rdmeto01.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.rdmeto01.json
@@ -31,7 +31,7 @@
         "name": {
             "en-GB": "Red Meteor Crater Corner",
             "fr-FR": "Virage de cratère météoritique rouge",
-            "de-DE": "Roter Meteoritenkrater-Ecke",
+            "de-DE": "Roter Meteoritenkrater - Ecke",
             "es-ES": "Esquina de cráter de meteorito rojo",
             "it-IT": "Curva del cratere meteoritico rosso",
             "nl-NL": "Bocht rode meteoorkrater",

--- a/objects/rct2tt/scenery_large/rct2.tt.rdmeto02.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.rdmeto02.json
@@ -31,7 +31,7 @@
         "name": {
             "en-GB": "Red Meteor Crater Corner",
             "fr-FR": "Virage de cratère météoritique rouge",
-            "de-DE": "Roter Meteoritenkrater-Ecke",
+            "de-DE": "Roter Meteoritenkrater - Ecke",
             "es-ES": "Esquina de cráter de meteorito rojo",
             "it-IT": "Curva del cratere meteoritico rosso",
             "nl-NL": "Bocht rode meteoorkrater",

--- a/objects/rct2tt/scenery_large/rct2.tt.shipb4x4.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.shipb4x4.json
@@ -114,7 +114,7 @@
         "name": {
             "en-GB": "Luxury Liner Bow",
             "fr-FR": "Proue de paquebot de luxe",
-            "de-DE": "Luxusliner Bug",
+            "de-DE": "Luxusliner - Bug",
             "es-ES": "Proa de crucero de lujo",
             "it-IT": "Prua della nave di linea di lusso",
             "nl-NL": "Boeg luxueus schip",

--- a/objects/rct2tt/scenery_large/rct2.tt.shipm4x4.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.shipm4x4.json
@@ -114,7 +114,7 @@
         "name": {
             "en-GB": "Luxury Liner Mid Section",
             "fr-FR": "Section médiane de paquebot de luxe",
-            "de-DE": "Luxusliner Mittelteil",
+            "de-DE": "Luxusliner - Mittelteil",
             "es-ES": "Sección media de crucero de lujo",
             "it-IT": "Sezione media della nave di linea di lusso",
             "nl-NL": "Middenstuk luxueus schip",

--- a/objects/rct2tt/scenery_large/rct2.tt.ships4x4.json
+++ b/objects/rct2tt/scenery_large/rct2.tt.ships4x4.json
@@ -114,7 +114,7 @@
         "name": {
             "en-GB": "Luxury Liner Stern",
             "fr-FR": "Poupe de paquebot de luxe",
-            "de-DE": "Luxusliner Heck",
+            "de-DE": "Luxusliner - Heck",
             "es-ES": "Popa de crucero de lujo",
             "it-IT": "Poppa della nave di linea di lusso",
             "nl-NL": "Achtersteven luxueus schip",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr01.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr01.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Structure Small",
             "fr-FR": "Petite structure extraterrestre",
-            "de-DE": "Außerirdische Struktur Klein",
+            "de-DE": "Außerirdisches Gebäude, klein",
             "es-ES": "Estructura alienígena pequeña",
             "it-IT": "Piccola struttura aliena",
             "nl-NL": "Kleine Buitenaardse Constructie",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr02.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr02.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Structure Small",
             "fr-FR": "Petite structure extraterrestre",
-            "de-DE": "Außerirdische Struktur Klein",
+            "de-DE": "Außerirdisches Gebäude, klein",
             "es-ES": "Estructura alienígena pequeña",
             "it-IT": "Piccola struttura aliena",
             "nl-NL": "Kleine Buitenaardse Constructie",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr03.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr03.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Structure Small",
             "fr-FR": "Petite structure extraterrestre",
-            "de-DE": "Außerirdische Struktur Klein",
+            "de-DE": "Außerirdisches Gebäude, klein",
             "es-ES": "Estructura alienígena pequeña",
             "it-IT": "Piccola struttura aliena",
             "nl-NL": "Kleine Buitenaardse Constructie",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr04.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr04.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Skylight Small",
             "fr-FR": "Petit voyant lumineux extraterrestre",
-            "de-DE": "Außerirdisches Oberlicht Klein",
+            "de-DE": "Außerirdisches Oberlicht, klein",
             "es-ES": "Claraboya alienígena pequeña",
             "it-IT": "Piccolo lucernario alieno",
             "nl-NL": "Kleine Buitenaards Bovenlicht",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr05.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr05.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Tower Bottom",
             "fr-FR": "Bas de la tour extraterrestre",
-            "de-DE": "Außerirdischer Turm Unten",
+            "de-DE": "Außerirdischer Turm, unten",
             "es-ES": "Fondo de torre alienígena",
             "it-IT": "Parte inferiore della torre aliena",
             "nl-NL": "Onderkant Buitenaardse Toren",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr06.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr06.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Tower Middle",
             "fr-FR": "Milieu de la tour extraterrestre",
-            "de-DE": "Außerirdischer Turm Mitte",
+            "de-DE": "Außerirdischer Turm, Mitte",
             "es-ES": "Medio de torre alienígena",
             "it-IT": "Parte intermedia della torre aliena",
             "nl-NL": "Midden Buitenaardse Toren",

--- a/objects/rct2tt/scenery_small/rct2.tt.alnstr07.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.alnstr07.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Alien Tower Top",
             "fr-FR": "Haut de la tour extraterrestre",
-            "de-DE": "Außerirdischer Turm Oben",
+            "de-DE": "Außerirdischer Turm, oben",
             "es-ES": "Parte superior de torre alienígena",
             "it-IT": "Parte superiore della torre aliena",
             "nl-NL": "Bovenkant Buitenaardse Toren",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec01.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec01.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec02.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec02.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Inverted Corner Section",
             "fr-FR": "Section de virage inversé art déco",
-            "de-DE": "Art Déco umgedrehter Eckabschnitt",
+            "de-DE": "Art Déco - umgedrehter Eckabschnitt",
             "es-ES": "Sección de esquina inversa Art Decó",
             "it-IT": "Sezione di curva invertita in art decò",
             "nl-NL": "Omgekeerd Bochtstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec03.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec03.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Door",
             "fr-FR": "Mur art déco avec porte",
-            "de-DE": "Art Déco Mauer mit Tür",
+            "de-DE": "Art Déco - Mauer mit Tür",
             "es-ES": "Muro Art Decó con puerta",
             "it-IT": "Muro in art decò con porta",
             "nl-NL": "Muur met deur Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec04.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec04.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Windows",
             "fr-FR": "Mur art déco avec fenêtres",
-            "de-DE": "Art Déco Mauer mit Fenstern",
+            "de-DE": "Art Déco - Mauer mit Fenstern",
             "es-ES": "Muro Art Decó con ventanas",
             "it-IT": "Muro in art decò con finestre",
             "nl-NL": "Muur met vensters Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec05.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec05.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Windows",
             "fr-FR": "Mur art déco avec fenêtres",
-            "de-DE": "Art Déco Mauer mit Fenstern",
+            "de-DE": "Art Déco - Mauer mit Fenstern",
             "es-ES": "Muro Art Decó con ventanas",
             "it-IT": "Muro in art decò con finestre",
             "nl-NL": "Muur met vensters Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec06.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec06.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Top Section",
             "fr-FR": "Section haute art déco",
-            "de-DE": "Art Déco oberer Abschnitt",
+            "de-DE": "Art Déco - oberer Abschnitt",
             "es-ES": "Sección superior Art Decó",
             "it-IT": "Sezione superiore in art decò",
             "nl-NL": "Bovenstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec07.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec07.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Corner Section",
             "fr-FR": "Section de virage art déco",
-            "de-DE": "Art Déco Eckabschnitt",
+            "de-DE": "Art Déco - Eckabschnitt",
             "es-ES": "Sección de esquina Art Decó",
             "it-IT": "Sezione di curva in art decò",
             "nl-NL": "Bochtstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec08.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec08.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Top Corner Section",
             "fr-FR": "Section de virage haut art déco",
-            "de-DE": "Art Déco oberer Eckabschnitt",
+            "de-DE": "Art Déco - oberer Eckabschnitt",
             "es-ES": "Sección superior de esquina Art Decó",
             "it-IT": "Sezione di curva superiore in art decò",
             "nl-NL": "Bovenbochtstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec09.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec09.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec10.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec10.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec11.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec11.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Corner with Windows",
             "fr-FR": "Virage art déco avec fenêtres",
-            "de-DE": "Art Déco Ecke mit Fenstern",
+            "de-DE": "Art Déco - Ecke mit Fenstern",
             "es-ES": "Esquina Art Decó con ventanas",
             "it-IT": "Curva in art decò con finestre",
             "nl-NL": "Bocht met vensters Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec12.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec12.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Corner with Railings",
             "fr-FR": "Virage art déco avec grille",
-            "de-DE": "Art Déco Ecke mit Geländer",
+            "de-DE": "Art Déco - Ecke mit Geländer",
             "es-ES": "Esquina Art Decó con balaustrada",
             "it-IT": "Curva in art decò con ringhiere",
             "nl-NL": "Bocht met railing Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec13.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec13.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Top Corner Section",
             "fr-FR": "Section de virage haut art déco",
-            "de-DE": "Art Déco oberer Eckabschnitt",
+            "de-DE": "Art Déco - oberer Eckabschnitt",
             "es-ES": "Sección superior de esquina Art Decó",
             "it-IT": "Sezione di curva superiore in art decò",
             "nl-NL": "Bovenbochtstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec14.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec14.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Corner with Windows",
             "fr-FR": "Virage art déco avec fenêtres",
-            "de-DE": "Art Déco Ecke mit Fenstern",
+            "de-DE": "Art Déco - Ecke mit Fenstern",
             "es-ES": "Esquina Art Decó con ventanas",
             "it-IT": "Curva in art decò con finestre",
             "nl-NL": "Bocht met vensters Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec15.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec15.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec16.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec16.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec17.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec17.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec18.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec18.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Art Deco Top Section",
             "fr-FR": "Section haute art déco",
-            "de-DE": "Art Déco oberer Abschnitt",
+            "de-DE": "Art Déco - oberer Abschnitt",
             "es-ES": "Sección superior Art Decó",
             "it-IT": "Sezione superiore in art decò",
             "nl-NL": "Bovenstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec19.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec19.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec20.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec20.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall Section",
             "fr-FR": "Section de mur art déco",
-            "de-DE": "Art Déco Mauerabschnitt",
+            "de-DE": "Art Déco - Mauerabschnitt",
             "es-ES": "Sección de muro Art Decó",
             "it-IT": "Sezione del muro in art decò",
             "nl-NL": "Stuk muur in artdecostijl",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec21.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec21.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Railings",
             "fr-FR": "Mur art déco avec grille",
-            "de-DE": "Art Déco Mauer mit Geländer",
+            "de-DE": "Art Déco - Mauer mit Geländer",
             "es-ES": "Muro Art Decó con balaustrada",
             "it-IT": "Muro in art decò con ringhiere",
             "nl-NL": "Muur met railing Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec22.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec22.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Railings",
             "fr-FR": "Mur art déco avec grille",
-            "de-DE": "Art Déco Mauer mit Geländer",
+            "de-DE": "Art Déco - Mauer mit Geländer",
             "es-ES": "Muro Art Decó con balaustrada",
             "it-IT": "Muro in art decò con ringhiere",
             "nl-NL": "Muur met railing Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec23.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec23.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Railings",
             "fr-FR": "Mur art déco avec grille",
-            "de-DE": "Art Déco Mauer mit Geländer",
+            "de-DE": "Art Déco - Mauer mit Geländer",
             "es-ES": "Muro Art Decó con balaustrada",
             "it-IT": "Muro in art decò con ringhiere",
             "nl-NL": "Muur met railing Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec24.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec24.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Wall with Railings",
             "fr-FR": "Mur art déco avec grille",
-            "de-DE": "Art Déco Mauer mit Geländer",
+            "de-DE": "Art Déco - Mauer mit Geländer",
             "es-ES": "Muro Art Decó con balaustrada",
             "it-IT": "Muro in art decò con ringhiere",
             "nl-NL": "Muur met railing Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec28.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec28.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Art Deco Roof Section",
             "fr-FR": "Section de toit art déco",
-            "de-DE": "Art Déco Dachabschnitt",
+            "de-DE": "Art Déco - Dachabschnitt",
             "es-ES": "Sección de tejado Art Decó",
             "it-IT": "Sezione di tetto in art decò",
             "nl-NL": "Dakstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.artdec29.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.artdec29.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Art Deco Inverted Corner Section",
             "fr-FR": "Section de virage inversé art déco",
-            "de-DE": "Art Déco umgedrehter Eckabschnitt",
+            "de-DE": "Art Déco - umgedrehter Eckabschnitt",
             "es-ES": "Sección de esquina inversa Art Decó",
             "it-IT": "Sezione di curva invertita in art decò",
             "nl-NL": "Omgekeerd Bochtstuk Art Deco",

--- a/objects/rct2tt/scenery_small/rct2.tt.dinsign1.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.dinsign1.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Neon Diner Sign",
             "fr-FR": "Néon lumineux de restaurant",
-            "de-DE": "Neonschild Café",
+            "de-DE": "Neonschild - Imbiss",
             "es-ES": "Anuncio de neón de restaurante",
             "it-IT": "Insegna al neon del ristorante",
             "nl-NL": "Neonembleem Cafetaria",

--- a/objects/rct2tt/scenery_small/rct2.tt.dinsign2.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.dinsign2.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Neon Diner Sign",
             "fr-FR": "Néon lumineux de restaurant",
-            "de-DE": "Neonschild Café",
+            "de-DE": "Neonschild - Imbiss",
             "es-ES": "Anuncio de neón de restaurante",
             "it-IT": "Insegna al neon del ristorante",
             "nl-NL": "Neonembleem Cafetaria",

--- a/objects/rct2tt/scenery_small/rct2.tt.dinsign3.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.dinsign3.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Neon Diner Sign",
             "fr-FR": "Néon lumineux de restaurant",
-            "de-DE": "Neonschild Café",
+            "de-DE": "Neonschild - Imbiss",
             "es-ES": "Anuncio de neón de restaurante",
             "it-IT": "Insegna al neon del ristorante",
             "nl-NL": "Neonembleem Cafetaria",

--- a/objects/rct2tt/scenery_small/rct2.tt.dinsign4.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.dinsign4.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Neon Diner Sign",
             "fr-FR": "Néon lumineux de restaurant",
-            "de-DE": "Neonschild Café",
+            "de-DE": "Neonschild - Imbiss",
             "es-ES": "Anuncio de neón de restaurante",
             "it-IT": "Insegna al neon del ristorante",
             "nl-NL": "Neonembleem Cafetaria",

--- a/objects/rct2tt/scenery_small/rct2.tt.frbeacon.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.frbeacon.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Fiery Beacon",
             "fr-FR": "Signal lumineux",
-            "de-DE": "Glühendes Leuchtfeuer",
+            "de-DE": "Leuchtfeuer",
             "es-ES": "Faro de fuego",
             "it-IT": "Falò ardente",
             "nl-NL": "Vuurbaken",

--- a/objects/rct2tt/scenery_small/rct2.tt.fwrprdc1.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.fwrprdc1.json
@@ -27,7 +27,7 @@
         "name": {
             "en-GB": "Groovy Dancer",
             "fr-FR": "Danseur émérite",
-            "de-DE": "Geiler Tänzer",
+            "de-DE": "Cooler Tänzer",
             "es-ES": "Buen bailarín",
             "it-IT": "Ballerino affascinante",
             "nl-NL": "Gave Danser",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal01.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal01.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Wall Set",
             "fr-FR": "Série de murs industriels",
-            "de-DE": "Industriemauer Set",
+            "de-DE": "Industriemauer-Set",
             "es-ES": "Conjunto de muros industriales",
             "it-IT": "Serie di muri di New York",
             "nl-NL": "Muren Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal02.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal02.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Wall Set",
             "fr-FR": "Série de murs industriels",
-            "de-DE": "Industriemauer Set",
+            "de-DE": "Industriemauer-Set",
             "es-ES": "Conjunto de muros industriales",
             "it-IT": "Serie di muri di New York",
             "nl-NL": "Muren Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal03.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal03.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Wall Set",
             "fr-FR": "Série de murs industriels",
-            "de-DE": "Industriemauer Set",
+            "de-DE": "Industriemauer-Set",
             "es-ES": "Conjunto de muros industriales",
             "it-IT": "Serie di muri di New York",
             "nl-NL": "Muren Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal04.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal04.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Wall Set",
             "fr-FR": "Série de murs industriels",
-            "de-DE": "Industriemauer Set",
+            "de-DE": "Industriemauer-Set",
             "es-ES": "Conjunto de muros industriales",
             "it-IT": "Serie di muri di New York",
             "nl-NL": "Muren Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal05.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal05.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Roof Corner Piece",
             "fr-FR": "Section de toit de virage industriel",
-            "de-DE": "Industriedach Eckstück",
+            "de-DE": "Industriedach-Eckstück",
             "es-ES": "Sección de esquina de tejado industrial",
             "it-IT": "Tratto di curva dei tetti di New York",
             "nl-NL": "Dak Bochtstuk Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal06.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal06.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Roof Corner Piece",
             "fr-FR": "Section de toit de virage industriel",
-            "de-DE": "Industriedach Eckstück",
+            "de-DE": "Industriedach-Eckstück",
             "es-ES": "Sección de esquina de tejado industrial",
             "it-IT": "Tratto di curva dei tetti di New York",
             "nl-NL": "Dak Bochtstuk Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal14.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal14.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Wall Corner Piece",
             "fr-FR": "Section de mur de virage industriel",
-            "de-DE": "Industriemauer Eckstück",
+            "de-DE": "Industriemauer-Eckstück",
             "es-ES": "Sección de esquina de muro industrial",
             "it-IT": "Tratto di curva del muro industriale",
             "nl-NL": "Muur Bochtstuk Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.indwal15.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.indwal15.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Industrial Wall Corner Piece",
             "fr-FR": "Section de mur de virage industriel",
-            "de-DE": "Industriemauer Eckstück",
+            "de-DE": "Industriemauer-Eckstück",
             "es-ES": "Sección de esquina de muro industrial",
             "it-IT": "Tratto di curva del muro industriale",
             "nl-NL": "Muur Bochtstuk Industrie",

--- a/objects/rct2tt/scenery_small/rct2.tt.largecpu.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.largecpu.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Super Computer Large CPU",
             "fr-FR": "Grande unité centrale de super ordinateur",
-            "de-DE": "Supercomputer Große Zentraleinheit",
+            "de-DE": "Supercomputer - Große Zentraleinheit",
             "es-ES": "Gran CPU de superordenador",
             "it-IT": "Grande CPU del super computer",
             "nl-NL": "Grote CPU Supercomputer",

--- a/objects/rct2tt/scenery_small/rct2.tt.mamthw03.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.mamthw03.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Large Angled Mammoth Fence",
             "fr-FR": "Clôture à mammouths très courbée",
-            "de-DE": "Großer Abgewinkelter Mammutzaun",
+            "de-DE": "Großer abgewinkelter Mammutzaun",
             "es-ES": "Gran valla angulosa de mamut",
             "it-IT": "Grande recinzione di mammut ad angolo",
             "nl-NL": "Mammoethek onder grote hoek",

--- a/objects/rct2tt/scenery_small/rct2.tt.mamthw04.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.mamthw04.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Large Angled Mammoth Fence",
             "fr-FR": "Clôture à mammouths très courbée",
-            "de-DE": "Großer Abgewinkelter Mammutzaun",
+            "de-DE": "Großer abgewinkelter Mammutzaun",
             "es-ES": "Gran valla angulosa de mamut",
             "it-IT": "Grande recinzione di mammut ad angolo",
             "nl-NL": "Mammoethek onder grote hoek",

--- a/objects/rct2tt/scenery_small/rct2.tt.mamthw05.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.mamthw05.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Small Angled Mammoth Fence",
             "fr-FR": "Clôture à mammouths peu courbée",
-            "de-DE": "Kleiner Abgewinkelter Mammutzaun",
+            "de-DE": "Kleiner abgewinkelter Mammutzaun",
             "es-ES": "Pequeña valla angulosa de mamut",
             "it-IT": "Piccola recinzione di mammut ad angolo",
             "nl-NL": "Mammoethek onder kleine hoek",

--- a/objects/rct2tt/scenery_small/rct2.tt.mamthw06.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.mamthw06.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Small Angled Mammoth Fence",
             "fr-FR": "Clôture à mammouths peu courbée",
-            "de-DE": "Kleiner Abgewinkelter Mammutzaun",
+            "de-DE": "Kleiner abgewinkelter Mammutzaun",
             "es-ES": "Pequeña valla angulosa de mamut",
             "it-IT": "Piccola recinzione di mammut ad angolo",
             "nl-NL": "Mammoethek onder kleine hoek",

--- a/objects/rct2tt/scenery_small/rct2.tt.primhead.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primhead.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primhear.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primhear.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primscrn.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primscrn.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primst01.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primst01.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primst02.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primst02.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primst03.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primst03.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primtall.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primtall.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Wood Fence with Man Eating Plant",
             "fr-FR": "Clôture de bois avec plante carnivore",
-            "de-DE": "Holzzaun mit Menschenfressender Pflanze",
+            "de-DE": "Holzzaun mit menschenfressender Pflanze",
             "es-ES": "Valla de madera con plantas carnívoras",
             "it-IT": "Recinto di legno con pianta carnivora",
             "nl-NL": "Houten hek met mensetende plant",

--- a/objects/rct2tt/scenery_small/rct2.tt.primwal1.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primwal1.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Wood Fence with Dead Vines",
             "fr-FR": "Clôture de bois avec vigne morte",
-            "de-DE": "Holzzaun mit Toten Ranken",
+            "de-DE": "Holzzaun mit toten Ranken",
             "es-ES": "Valla de madera con enredaderas muertas",
             "it-IT": "Recinto di legno con viticci morti",
             "nl-NL": "Houten hek met dode wijnstokken",

--- a/objects/rct2tt/scenery_small/rct2.tt.primwal2.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primwal2.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Wood Fence with Dead Vines",
             "fr-FR": "Clôture de bois avec vigne morte",
-            "de-DE": "Holzzaun mit Toten Ranken",
+            "de-DE": "Holzzaun mit toten Ranken",
             "es-ES": "Valla de madera con enredaderas muertas",
             "it-IT": "Recinto di legno con viticci morti",
             "nl-NL": "Houten hek met dode wijnstokken",

--- a/objects/rct2tt/scenery_small/rct2.tt.primwal3.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.primwal3.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Wood Fence with Dead Vines",
             "fr-FR": "Clôture de bois avec vigne morte",
-            "de-DE": "Holzzaun mit Toten Ranken",
+            "de-DE": "Holzzaun mit toten Ranken",
             "es-ES": "Valla de madera con enredaderas muertas",
             "it-IT": "Recinto di legno con viticci morti",
             "nl-NL": "Houten hek met dode wijnstokken",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl01.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl01.json
@@ -29,7 +29,7 @@
         "name": {
             "en-GB": "Dark Age Village Roof with Chimney",
             "fr-FR": "Toit avec cheminée du village médiéval",
-            "de-DE": "Dach mit Kamin Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dach mit Kamin",
             "es-ES": "Tejado con chimenea de pueblo medieval",
             "it-IT": "Tetto con camino del villaggio dell'Età Oscura",
             "nl-NL": "Dak met schoorsteen middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl02.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl02.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Wall Piece",
             "fr-FR": "Section basse de mur du village médiéval",
-            "de-DE": "Unteres Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Mauerstück",
             "es-ES": "Sección inferior de muro de pueblo medieval",
             "it-IT": "Tratto di muro inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl03.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl03.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Wall Piece",
             "fr-FR": "Section basse de mur du village médiéval",
-            "de-DE": "Unteres Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Mauerstück",
             "es-ES": "Sección inferior de muro de pueblo medieval",
             "it-IT": "Tratto di muro inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl04.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl04.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Wall Piece",
             "fr-FR": "Section basse de mur du village médiéval",
-            "de-DE": "Unteres Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Mauerstück",
             "es-ES": "Sección inferior de muro de pueblo medieval",
             "it-IT": "Tratto di muro inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl05.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl05.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Wall Piece",
             "fr-FR": "Section basse de mur du village médiéval",
-            "de-DE": "Unteres Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Mauerstück",
             "es-ES": "Sección inferior de muro de pueblo medieval",
             "it-IT": "Tratto di muro inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl06.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl06.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Wall Piece",
             "fr-FR": "Section basse de mur du village médiéval",
-            "de-DE": "Unteres Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Mauerstück",
             "es-ES": "Sección inferior de muro de pueblo medieval",
             "it-IT": "Tratto di muro inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl07.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl07.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Wall Piece",
             "fr-FR": "Section basse de mur du village médiéval",
-            "de-DE": "Unteres Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Mauerstück",
             "es-ES": "Sección inferior de muro de pueblo medieval",
             "it-IT": "Tratto di muro inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl08.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl08.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Lower Corner Piece",
             "fr-FR": "Section basse de virage du village médiéval",
-            "de-DE": "Unteres Eckstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Unteres Eckstück",
             "es-ES": "Sección inferior de esquina de pueblo medieval",
             "it-IT": "Tratto di curva inferiore del villaggio dell'Età Oscura",
             "nl-NL": "Benedenstuk bocht middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl09.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl09.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Upper Wall Piece",
             "fr-FR": "Section haute de mur du village médiéval",
-            "de-DE": "Oberes Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Oberes Mauerstück",
             "es-ES": "Sección superior de muro de pueblo medieval",
             "it-IT": "Tratto di muro superiore del villaggio dell'Età Oscura",
             "nl-NL": "Bovenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl10.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl10.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Upper Wall Piece",
             "fr-FR": "Section haute de mur du village médiéval",
-            "de-DE": "Oberes Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Oberes Mauerstück",
             "es-ES": "Sección superior de muro de pueblo medieval",
             "it-IT": "Tratto di muro superiore del villaggio dell'Età Oscura",
             "nl-NL": "Bovenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl11.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl11.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Upper Wall Piece",
             "fr-FR": "Section haute de mur du village médiéval",
-            "de-DE": "Oberes Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Oberes Mauerstück",
             "es-ES": "Sección superior de muro de pueblo medieval",
             "it-IT": "Tratto di muro superiore del villaggio dell'Età Oscura",
             "nl-NL": "Bovenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl12.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl12.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Upper Wall Piece",
             "fr-FR": "Section haute de mur du village médiéval",
-            "de-DE": "Oberes Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Oberes Mauerstück",
             "es-ES": "Sección superior de muro de pueblo medieval",
             "it-IT": "Tratto di muro superiore del villaggio dell'Età Oscura",
             "nl-NL": "Bovenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl13.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl13.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Upper Wall Piece",
             "fr-FR": "Section haute de mur du village médiéval",
-            "de-DE": "Oberes Mauerstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Oberes Mauerstück",
             "es-ES": "Sección superior de muro de pueblo medieval",
             "it-IT": "Tratto di muro superiore del villaggio dell'Età Oscura",
             "nl-NL": "Bovenstuk muur middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl14.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl14.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Roof Piece",
             "fr-FR": "Section de toit du village médiéval",
-            "de-DE": "Dachstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dachstück",
             "es-ES": "Sección de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto del villaggio dell'Età Oscura",
             "nl-NL": "Dakstuk middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl15.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl15.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Inverted Roof Piece",
             "fr-FR": "Section de toit inversé du village médiéval",
-            "de-DE": "Umgedrehtes Dachstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Umgedrehtes Dachstück",
             "es-ES": "Sección inversa de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto invertito del villaggio dell'Età Oscura",
             "nl-NL": "Omgekeerd dakstuk middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl16.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl16.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Roof Piece",
             "fr-FR": "Section de toit du village médiéval",
-            "de-DE": "Dachstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dachstück",
             "es-ES": "Sección de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto del villaggio dell'Età Oscura",
             "nl-NL": "Dakstuk middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl17.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl17.json
@@ -24,7 +24,7 @@
         "name": {
             "en-GB": "Dark Age Village Roof Piece",
             "fr-FR": "Section de toit du village médiéval",
-            "de-DE": "Dachstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dachstück",
             "es-ES": "Sección de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto del villaggio dell'Età Oscura",
             "nl-NL": "Dakstuk middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl20.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl20.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Window Box Roof",
             "fr-FR": "Toit de jardinière du village médiéval",
-            "de-DE": "Dach-Blumenkasten Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Balkonkastendach",
             "es-ES": "Ventana de tejado de pueblo medieval",
             "it-IT": "Copertura dei vasi di fiori del villaggio dell'Età Oscura",
             "nl-NL": "Dak vensterraam middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl21.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl21.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Window Box Roof",
             "fr-FR": "Toit de jardinière du village médiéval",
-            "de-DE": "Dach-Blumenkasten Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Balkonkastendach",
             "es-ES": "Ventana de tejado de pueblo medieval",
             "it-IT": "Copertura dei vasi di fiori del villaggio dell'Età Oscura",
             "nl-NL": "Dak vensterraam middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl23.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl23.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Upper Corner Piece",
             "fr-FR": "Section haute de virage du village médiéval",
-            "de-DE": "Oberes Eckstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Oberes Eckstück",
             "es-ES": "Sección inferior de esquina de pueblo medieval",
             "it-IT": "Tratto di curva superiore del villaggio dell'Età Oscura",
             "nl-NL": "Bovenstuk bocht middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl24.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl24.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Window Box",
             "fr-FR": "Jardinière du village médiéval",
-            "de-DE": "Blumenkasten Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Balkonkasten",
             "es-ES": "Ventana de pueblo medieval",
             "it-IT": "Vasi di fiori del villaggio dell'Età Oscura",
             "nl-NL": "Vensterraam middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl25.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl25.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Window Box",
             "fr-FR": "Jardinière du village médiéval",
-            "de-DE": "Blumenkasten Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Balkonkasten",
             "es-ES": "Ventana de pueblo medieval",
             "it-IT": "Vasi di fiori del villaggio dell'Età Oscura",
             "nl-NL": "Vensterraam middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl29.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl29.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Window Box Roof",
             "fr-FR": "Toit de jardinière du village médiéval",
-            "de-DE": "Dach-Blumenkasten Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Balkonkastendach",
             "es-ES": "Ventana de tejado de pueblo medieval",
             "it-IT": "Copertura dei vasi di fiori del villaggio dell'Età Oscura",
             "nl-NL": "Dak vensterraam middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl30.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl30.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Window Box Roof",
             "fr-FR": "Toit de jardinière du village médiéval",
-            "de-DE": "Dach-Blumenkasten Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Balkonkastendach",
             "es-ES": "Ventana de tejado de pueblo medieval",
             "it-IT": "Copertura dei vasi di fiori del villaggio dell'Età Oscura",
             "nl-NL": "Dak vensterraam middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.psntwl31.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.psntwl31.json
@@ -25,7 +25,7 @@
         "name": {
             "en-GB": "Dark Age Village Corner Roof Piece",
             "fr-FR": "Section de toit du virage du village médiéval",
-            "de-DE": "Dacheckstück Mittelalterliches Dorf",
+            "de-DE": "Mittelalterdorf - Dacheckstück",
             "es-ES": "Sección de esquina de tejado de pueblo medieval",
             "it-IT": "Tratto di tetto in curva del villaggio dell'Età Oscura",
             "nl-NL": "Bochtstuk dak middeleeuws dorp",

--- a/objects/rct2tt/scenery_small/rct2.tt.smallcpu.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.smallcpu.json
@@ -30,7 +30,7 @@
         "name": {
             "en-GB": "Super Computer Small CPU",
             "fr-FR": "Petite unité centrale de super ordinateur",
-            "de-DE": "Supercomputer Kleine Zentraleinheit",
+            "de-DE": "Supercomputer - Kleine Zentraleinheit",
             "es-ES": "Pequeña CPU de superordenador",
             "it-IT": "Piccola CPU del super computer",
             "nl-NL": "Kleine CPU Supercomputer",

--- a/objects/rct2tt/scenery_small/rct2.tt.smoksk01.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.smoksk01.json
@@ -27,7 +27,7 @@
         "name": {
             "en-GB": "Large Smoking Chimney",
             "fr-FR": "Grande cheminée fumante",
-            "de-DE": "Großer Rauchender Kamin",
+            "de-DE": "Großer rauchender Kamin",
             "es-ES": "Gran chimenea humeante",
             "it-IT": "Grande ciminiera fumante",
             "nl-NL": "Grote rokende schoorsteen",

--- a/objects/rct2tt/scenery_small/rct2.tt.volcvent.json
+++ b/objects/rct2tt/scenery_small/rct2.tt.volcvent.json
@@ -28,7 +28,7 @@
         "name": {
             "en-GB": "Active Volcanic Vent",
             "fr-FR": "Cheminée de volcan actif",
-            "de-DE": "Aktive Vulkanische Öffnung",
+            "de-DE": "Aktiver Vulkanschlot",
             "es-ES": "Chimenea de volcán activo",
             "it-IT": "Cratere di vulcano attivo",
             "nl-NL": "Actieve vulkanische uitlaat",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x2abr01.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x2abr01.json
@@ -31,7 +31,7 @@
         "name": {
             "en-GB": "Aboriginal Plain Tile",
             "fr-FR": "Tuile aborigène unie",
-            "de-DE": "Von Aborigines gefertigte schlichte Kachel",
+            "de-DE": "Aborigine-Kunst - Schlichte Kachel",
             "es-ES": "Baldosa sencilla aborigen",
             "it-IT": "Piastrella semplice in stile aborigeno",
             "nl-NL": "Tegel Aboriginals",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x2abr02.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x2abr02.json
@@ -31,7 +31,7 @@
         "name": {
             "en-GB": "Aboriginal Snake Artwork",
             "fr-FR": "Oeuvre serpent aborigène",
-            "de-DE": "Von Aborigines gefertigtes Schlangen-Kunstwerk",
+            "de-DE": "Aborigine-Kunst - Schlangen-Kunstwerk",
             "es-ES": "Arte serpiente aborigen",
             "it-IT": "Opera d'arte aborigena a forma di serpente",
             "nl-NL": "Slangkunstwerk Aboriginals",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x2abr03.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x2abr03.json
@@ -31,7 +31,7 @@
         "name": {
             "en-GB": "Aboriginal Spirit Artwork",
             "fr-FR": "Oeuvre esprit aborigène",
-            "de-DE": "Von Aborigines gefertigtes Geister-Kunstwerk",
+            "de-DE": "Aborigine-Kunst - Geister-Kunstwerk",
             "es-ES": "Arte espíritu aborigen",
             "it-IT": "Opera d'arte aborigena a tema spirituale",
             "nl-NL": "Spiritueel kunstwerk Aboriginals",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x4brg01.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x4brg01.json
@@ -45,7 +45,7 @@
         "name": {
             "en-GB": "Suspension Bridge Start side 1",
             "fr-FR": "Extrémité 1 de pont suspendu",
-            "de-DE": "Hängebrücke - Anfangsstück Seite 1",
+            "de-DE": "Hängebrücke - Anfangsstück, Seite 1",
             "es-ES": "Lado 1 del inicio del puente suspendido",
             "it-IT": "Testa di ponte sospeso, lato 1",
             "nl-NL": "Begingedeelte Hangbrug 1",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x4brg02.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x4brg02.json
@@ -45,7 +45,7 @@
         "name": {
             "en-GB": "Suspension Bridge Start side 2",
             "fr-FR": "Extrémité 2 de pont suspendu",
-            "de-DE": "Hängebrücke - Anfangsstück Seite 2",
+            "de-DE": "Hängebrücke - Anfangsstück, Seite 2",
             "es-ES": "Lado 2 del inicio del puente suspendido",
             "it-IT": "Testa di ponte sospeso, lato 2",
             "nl-NL": "Begingedeelte Hangbrug 2",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x4brg03.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x4brg03.json
@@ -45,7 +45,7 @@
         "name": {
             "en-GB": "Suspension Bridge Tower side 1",
             "fr-FR": "Tour 1 de pont suspendu",
-            "de-DE": "Hängebrücke - Turm Seite 1",
+            "de-DE": "Hängebrücke - Turm, Seite 1",
             "es-ES": "Lado 1 de la torre del puente suspendido",
             "it-IT": "Torre di ponte sospeso, lato 1",
             "nl-NL": "Torengedeelte Hangbrug 1",

--- a/objects/rct2ww/scenery_large/rct2.ww.1x4brg04.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x4brg04.json
@@ -45,7 +45,7 @@
         "name": {
             "en-GB": "Suspension Bridge Tower side 2",
             "fr-FR": "Tour 2 de pont suspendu",
-            "de-DE": "Hängebrücke - Turm Seite 2",
+            "de-DE": "Hängebrücke - Turm, Seite 2",
             "es-ES": "Lado 2 de la torre del puente suspendido",
             "it-IT": "Torre di ponte sospeso, lato 2",
             "nl-NL": "Torengedeelte Hangbrug 2",

--- a/objects/rct2ww/scenery_large/rct2.ww.3x3mantr.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.3x3mantr.json
@@ -73,7 +73,7 @@
         "name": {
             "en-GB": "Mangrove Tree",
             "fr-FR": "Arbre forêt équatoriale 1 3",
-            "de-DE": "Regenwaldbaum 3",
+            "de-DE": "Mangrovenbaum",
             "es-ES": "Árbol tropical 3",
             "it-IT": "Albero di foresta pluviale 3",
             "nl-NL": "Mangroveboom",

--- a/objects/rct2ww/scenery_large/rct2.ww.easerlnd.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.easerlnd.json
@@ -46,7 +46,7 @@
         "name": {
             "en-GB": "Easter Island Statue",
             "fr-FR": "Statue de l'île de Pâques 1",
-            "de-DE": "Osterinselstatue 1",
+            "de-DE": "Osterinselstatue",
             "es-ES": "Estatua de la isla de Pascua 1",
             "it-IT": "Statua dell'isola di Pasqua 1",
             "nl-NL": "Beeld Paaseiland 1",

--- a/objects/rct2ww/scenery_large/rct2.ww.gwoctur1.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.gwoctur1.json
@@ -81,7 +81,7 @@
         "name": {
             "en-GB": "Great Wall Of China Turret Straight",
             "fr-FR": "Tourelle droite de la Grande Muraille de Chine",
-            "de-DE": "Große Mauer von China - Geradentürmchen",
+            "de-DE": "Chinesische Mauer - Geradentürmchen",
             "es-ES": "Recta de torre de la Gran Muralla China",
             "it-IT": "Angolo della Grande Muraglia Cinese con torre",
             "nl-NL": "Rechte Koepel Grote Chinese Muur",

--- a/objects/rct2ww/scenery_large/rct2.ww.gwoctur2.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.gwoctur2.json
@@ -81,7 +81,7 @@
         "name": {
             "en-GB": "Great Wall Of China Turret Corner",
             "fr-FR": "Tourelle en coin de la Grande Muraille de Chine",
-            "de-DE": "Große Mauer von China - Ecktürmchen",
+            "de-DE": "Chinesische Mauer - Ecktürmchen",
             "es-ES": "Esquina de torre de la Gran Muralla China",
             "it-IT": "Sezione diritta della Grande Muraglia Cinese con torre",
             "nl-NL": "Hoek-Koepel Grote Chinese Muur",

--- a/objects/rct2ww/scenery_large/rct2.ww.largeju1.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.largeju1.json
@@ -43,7 +43,7 @@
         "name": {
             "en-GB": "Large Rainforest Tree",
             "fr-FR": "Arbre forêt équatoriale 1 4",
-            "de-DE": "Regenwaldbaum 4",
+            "de-DE": "Großer Regenwaldbaum",
             "es-ES": "Árbol tropical 4",
             "it-IT": "Albero di foresta pluviale 4",
             "nl-NL": "Regenwoudboom 4",

--- a/objects/rct2ww/scenery_small/rct2.ww.antilopp.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.antilopp.json
@@ -20,7 +20,7 @@
         "name": {
             "en-GB": "Antelope Pair",
             "fr-FR": "Couple d'antilopes",
-            "de-DE": "Antilope (Paar)",
+            "de-DE": "Antilopenpaar",
             "es-ES": "Pareja de antílopes",
             "it-IT": "Coppia di antilopi",
             "nl-NL": "Paar Antilopen",

--- a/objects/rct2ww/scenery_small/rct2.ww.fountarc.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.fountarc.json
@@ -27,7 +27,7 @@
         "name": {
             "en-GB": "Australian Fountain Set 2",
             "fr-FR": "Fontaine australienne 2",
-            "de-DE": "Australischer Brunnen Set 2",
+            "de-DE": "Australisches Brunnen-Set 2",
             "es-ES": "Conjunto fuente australiana 2",
             "it-IT": "Fontane australiane, gruppo 2",
             "nl-NL": "Australisch stuk Fontein 2",

--- a/objects/rct2ww/scenery_small/rct2.ww.fountrow.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.fountrow.json
@@ -27,7 +27,7 @@
         "name": {
             "en-GB": "Australian Fountain Set 2",
             "fr-FR": "Fontaine australienne 2",
-            "de-DE": "Australischer Brunnen Set 2",
+            "de-DE": "Australisches Brunnen-Set 2",
             "es-ES": "Conjunto fuente australiana 2",
             "it-IT": "Fontane australiane, gruppo 2",
             "nl-NL": "Australisch stuk Fontein 2",

--- a/objects/rct2ww/scenery_small/rct2.ww.g1dancer.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.g1dancer.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Mardi Gras Dancer",
             "fr-FR": "Danseur Mardi Gras",
-            "de-DE": "Mardi Gras-Tänzer",
+            "de-DE": "Mardi-Gras-Tänzer",
             "es-ES": "Bailarín de Mardi Gras",
             "it-IT": "Danzatore del Mardi Gras",
             "nl-NL": "Carnavalsdanseres",

--- a/objects/rct2ww/scenery_small/rct2.ww.g2dancer.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.g2dancer.json
@@ -26,7 +26,7 @@
         "name": {
             "en-GB": "Mardi Gras Dancer",
             "fr-FR": "Danseur Mardi Gras",
-            "de-DE": "Mardi Gras-Tänzer",
+            "de-DE": "Mardi-Gras-Tänzer",
             "es-ES": "Bailarín de Mardi Gras",
             "it-IT": "Danzatore del Mardi Gras",
             "nl-NL": "Carnavalsdanseres",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick01.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick01.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Inverted Roof Piece",
             "fr-FR": "Pan de toit inversé de brique rouge",
-            "de-DE": "Backstein umgedrehtes Dach-Bauteil",
+            "de-DE": "Backsteindach-Bauteil, umgedreht",
             "es-ES": "Pieza invertida de tejado de ladrillo rojo",
             "it-IT": "Pezzo di tetto invertito di mattoni rossi",
             "nl-NL": "Omgekeerd stuk dak van rode baksteen",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick02.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick02.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Corner Roof Piece",
             "fr-FR": "Pan de toit en coin de brique rouge",
-            "de-DE": "Backstein Eck-Dachbauteil",
+            "de-DE": "Backstein-Eckdachbauteil",
             "es-ES": "Pieza de la esquina de tejado de ladrillo rojo",
             "it-IT": "Pezzo d'angolo di tetto di mattoni rossi",
             "nl-NL": "Hoekstuk dak van rode baksteen",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick03.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick03.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Flat Roof Edge Piece",
             "fr-FR": "Bord de toit plat de brique rouge",
-            "de-DE": "Backstein Flachdach-Kantenbauteil",
+            "de-DE": "Backstein-Flachdach-Kantenbauteil",
             "es-ES": "Pieza de borde de tejado plano de ladrillo rojo",
             "it-IT": "Pezzo d'orlo di tetto piatto di mattoni rossi",
             "nl-NL": "Randstuk voor plat dak van rode baksteen",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick04.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick04.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Flat Roof Corner",
             "fr-FR": "Coin de toit plat de brique rouge",
-            "de-DE": "Backstein Flachdachecke",
+            "de-DE": "Backstein-Flachdachecke",
             "es-ES": "Esquina de tejado plano de ladrillo rojo",
             "it-IT": "Angolo di tetto piatto di mattoni rossi",
             "nl-NL": "Hoekstuk voor plat dak van rode baksteen",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick05.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick05.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Roof Piece 2",
             "fr-FR": "Pan de toit de brique rouge 2",
-            "de-DE": "Backstein Dach-Bauteil 2",
+            "de-DE": "Backsteindach-Bauteil 2",
             "es-ES": "Pieza de tejado de ladrillo rojo 2",
             "it-IT": "Pezzo di tetto di mattoni rossi 2",
             "nl-NL": "Stuk dak van rode baksteen 2",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick07.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick07.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Roof Piece 3",
             "fr-FR": "Pan de toit de brique rouge 3",
-            "de-DE": "Backstein Dach-Bauteil 3",
+            "de-DE": "Backsteindach-Bauteil 3",
             "es-ES": "Pieza de tejado de ladrillo rojo 3",
             "it-IT": "Pezzo di tetto di mattoni rossi 3",
             "nl-NL": "Stuk dak van rode baksteen 3",

--- a/objects/rct2ww/scenery_small/rct2.ww.rbrick08.json
+++ b/objects/rct2ww/scenery_small/rct2.ww.rbrick08.json
@@ -21,7 +21,7 @@
         "name": {
             "en-GB": "Red Brick Roof Piece 1",
             "fr-FR": "Pan de toit de brique rouge 1",
-            "de-DE": "Backstein Dach-Bauteil 1",
+            "de-DE": "Backsteindach-Bauteil 1",
             "es-ES": "Pieza de tejado de ladrillo rojo 1",
             "it-IT": "Pezzo di tetto di mattoni rossi 1",
             "nl-NL": "Stuk dak van rode baksteen 1",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick01.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick01.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 1",
             "fr-FR": "Pan de mur de brique rouge 1",
-            "de-DE": "Backstein Wand-Bauteil 1",
+            "de-DE": "Backsteinmauer-Bauteil 1",
             "es-ES": "Pieza de pared de ladrillo rojo 1",
             "it-IT": "Pezzo di muro di mattoni rossi 1",
             "nl-NL": "Stuk muur van rode baksteen 1",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick02.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick02.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 2",
             "fr-FR": "Pan de mur de brique rouge 2",
-            "de-DE": "Backstein Wand-Bauteil 2",
+            "de-DE": "Backsteinmauer-Bauteil 2",
             "es-ES": "Pieza de pared de ladrillo rojo 2",
             "it-IT": "Pezzo di muro di mattoni rossi 2",
             "nl-NL": "Stuk muur van rode baksteen 2",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick03.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick03.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 3",
             "fr-FR": "Pan de mur de brique rouge 3",
-            "de-DE": "Backstein Wand-Bauteil 3",
+            "de-DE": "Backsteinmauer-Bauteil 3",
             "es-ES": "Pieza de pared de ladrillo rojo 3",
             "it-IT": "Pezzo di muro di mattoni rossi 3",
             "nl-NL": "Stuk muur van rode baksteen 3",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick04.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick04.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 4",
             "fr-FR": "Pan de mur de brique rouge 4",
-            "de-DE": "Backstein Wand-Bauteil 4",
+            "de-DE": "Backsteinmauer-Bauteil 4",
             "es-ES": "Pieza de pared de ladrillo rojo 4",
             "it-IT": "Pezzo di muro di mattoni rossi 4",
             "nl-NL": "Stuk muur van rode baksteen 4",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick05.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick05.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 5",
             "fr-FR": "Pan de mur de brique rouge 5",
-            "de-DE": "Backstein Wand-Bauteil 5",
+            "de-DE": "Backsteinmauer-Bauteil 5",
             "es-ES": "Pieza de pared de ladrillo rojo 5",
             "it-IT": "Pezzo di muro di mattoni rossi 5",
             "nl-NL": "Stuk muur van rode baksteen 5",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick08.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick08.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 8",
             "fr-FR": "Pan de mur de brique rouge 8",
-            "de-DE": "Backstein Wand-Bauteil 8",
+            "de-DE": "Backsteinmauer-Bauteil 8",
             "es-ES": "Pieza de pared de ladrillo rojo 8",
             "it-IT": "Pezzo di muro di mattoni rossi 8",
             "nl-NL": "Stuk muur van rode baksteen 8",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick11.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick11.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 11",
             "fr-FR": "Pan de mur de brique rouge 11",
-            "de-DE": "Backstein Wand-Bauteil 11",
+            "de-DE": "Backsteinmauer-Bauteil 11",
             "es-ES": "Pieza de pared de ladrillo rojo 11",
             "it-IT": "Pezzo di muro di mattoni rossi 11",
             "nl-NL": "Stuk muur van rode baksteen 11",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick12.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick12.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 12",
             "fr-FR": "Pan de mur de brique rouge 12",
-            "de-DE": "Backstein Wand-Bauteil 12",
+            "de-DE": "Backsteinmauer-Bauteil 12",
             "es-ES": "Pieza de pared de ladrillo rojo 12",
             "it-IT": "Pezzo di muro di mattoni rossi 12",
             "nl-NL": "Stuk muur van rode baksteen 12",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wbrick13.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wbrick13.json
@@ -16,7 +16,7 @@
         "name": {
             "en-GB": "Red Brick Wall Piece 13",
             "fr-FR": "Pan de mur de brique rouge 13",
-            "de-DE": "Backstein Wand-Bauteil 13",
+            "de-DE": "Backsteinmauer-Bauteil 13",
             "es-ES": "Pieza de pared de ladrillo rojo 13",
             "it-IT": "Pezzo di muro di mattoni rossi 13",
             "nl-NL": "Stuk muur van rode baksteen 13",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wgwoc1.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wgwoc1.json
@@ -15,7 +15,7 @@
         "name": {
             "en-GB": "Great Wall Of China Front Wall Section",
             "fr-FR": "Section du mur avant de la Grande Muraille de Chine",
-            "de-DE": "Große Mauer von China - Vordersektion",
+            "de-DE": "Chinesische Mauer - Vordersektion",
             "es-ES": "Sec. frontal de la pared de la Gran Muralla China",
             "it-IT": "Sezione frontale di parete della Grande Muraglia Cinese",
             "nl-NL": "Stuk Voorkant van Grote Chinese Muur",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wgwoc2.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wgwoc2.json
@@ -15,7 +15,7 @@
         "name": {
             "en-GB": "Great Wall Of China Rear Wall Section",
             "fr-FR": "Section de mur arrière de la Grande Muraille de Chine",
-            "de-DE": "Große Mauer von China - Rückwand-Abschnitt",
+            "de-DE": "Chinesische Mauer - Rückwand-Abschnitt",
             "es-ES": "Sec. trasera de la pared de la Gran Muralla China",
             "it-IT": "Sezione posteriore di parete della Grande Muraglia Cinese",
             "nl-NL": "Stuk muur achterkant Grote Chinese Muur",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wgwoc3.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wgwoc3.json
@@ -15,7 +15,7 @@
         "name": {
             "en-GB": "Great Wall Of China Step up Wall Section",
             "fr-FR": "Section de mur avec montée de la Grande Muraille de Chine",
-            "de-DE": "Große Mauer von China - Treppen-Wandabschnitt",
+            "de-DE": "Chinesische Mauer - Treppen-Wandabschnitt",
             "es-ES": "Sec. de pared de las escaleras de la Gran Muralla",
             "it-IT": "Sezione di parete rialzata della Grande Muraglia Cinese",
             "nl-NL": "Stuk muur met Trap Grote Chinese Muur",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wskysc04.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wskysc04.json
@@ -15,7 +15,7 @@
         "name": {
             "en-GB": "Skyscraper Lift Section Piece",
             "fr-FR": "Pièce de section d'ascenseur de gratte-ciel",
-            "de-DE": "Wolkenkratzer Aufzugssektion-Bauteil",
+            "de-DE": "Wolkenkratzer-Aufzugssektions-Bauteil",
             "es-ES": "Pieza de la sección del ascensor del rascacielos",
             "it-IT": "Pezzo di sezione di ascensore del grattacielo",
             "nl-NL": "Stuk Lift Wolkenkrabber",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wskysc05.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wskysc05.json
@@ -15,7 +15,7 @@
         "name": {
             "en-GB": "Skyscraper Lift Section Piece",
             "fr-FR": "Pièce de section d'ascenseur de gratte-ciel",
-            "de-DE": "Wolkenkratzer Aufzugssektion-Bauteil",
+            "de-DE": "Wolkenkratzer-Aufzugssektions-Bauteil",
             "es-ES": "Pieza de la sección del ascensor del rascacielos",
             "it-IT": "Pezzo di sezione di ascensore del grattacielo",
             "nl-NL": "Stuk Lift Wolkenkrabber",

--- a/objects/rct2ww/scenery_wall/rct2.ww.wskysc07.json
+++ b/objects/rct2ww/scenery_wall/rct2.ww.wskysc07.json
@@ -15,7 +15,7 @@
         "name": {
             "en-GB": "Skyscraper Lift Section Piece",
             "fr-FR": "Pièce de section d'ascenseur de gratte-ciel",
-            "de-DE": "Wolkenkratzer Aufzugssektion-Bauteil",
+            "de-DE": "Wolkenkratzer-Aufzugssektions-Bauteil",
             "es-ES": "Pieza de la sección del ascensor del rascacielos",
             "it-IT": "Pezzo di sezione di ascensore del grattacielo",
             "nl-NL": "Stuk Lift Wolkenkrabber",


### PR DESCRIPTION
This PR updates German scenery translations. It's mostly grammar/spelling fixes, and some incorrect or weird translations are changed.