### PR TITLE
Wacky Worlds Large Scenery Updates

### DIFF
--- a/objects/rct2ww/scenery_large/rct2.ww.1x2abr02.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x2abr02.json
@@ -11,6 +11,7 @@
         "cursor": "CURSOR_STATUE_DOWN",
         "hasPrimaryColour": true,
         "hasSecondaryColour": true,
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.1x2abr03.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.1x2abr03.json
@@ -11,6 +11,7 @@
         "cursor": "CURSOR_STATUE_DOWN",
         "hasPrimaryColour": true,
         "hasSecondaryColour": true,
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.3x3atre1.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.3x3atre1.json
@@ -9,6 +9,7 @@
         "price": 36,
         "removalPrice": 28,
         "cursor": "CURSOR_TREE_DOWN",
+        "isPhotogenic": true,
         "sceneryGroup": "SCGTREES",
         "isTree": true,
         "tiles": [

--- a/objects/rct2ww/scenery_large/rct2.ww.3x3mantr.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.3x3mantr.json
@@ -9,6 +9,7 @@
         "price": 48,
         "removalPrice": 36,
         "cursor": "CURSOR_TREE_DOWN",
+        "isPhotogenic": true,
         "sceneryGroup": "SCGTREES",
         "isTree": true,
         "tiles": [

--- a/objects/rct2ww/scenery_large/rct2.ww.50rocket.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.50rocket.json
@@ -9,6 +9,7 @@
         "price": 124,
         "removalPrice": -102,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.afrclion.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.afrclion.json
@@ -9,6 +9,7 @@
         "price": 62,
         "removalPrice": -56,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.afrrhino.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.afrrhino.json
@@ -9,6 +9,7 @@
         "price": 68,
         "removalPrice": -64,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.afrzebra.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.afrzebra.json
@@ -9,6 +9,7 @@
         "price": 54,
         "removalPrice": -48,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.atractor.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.atractor.json
@@ -9,6 +9,7 @@
         "price": 72,
         "removalPrice": -67,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.biggeosp.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.biggeosp.json
@@ -9,6 +9,7 @@
         "price": 82,
         "removalPrice": -77,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.circus.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.circus.json
@@ -9,6 +9,7 @@
         "price": 68,
         "removalPrice": -54,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.cowboy01.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.cowboy01.json
@@ -9,6 +9,7 @@
         "price": 86,
         "removalPrice": -78,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.cowboy02.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.cowboy02.json
@@ -9,6 +9,7 @@
         "price": 86,
         "removalPrice": -78,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.damtower.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.damtower.json
@@ -9,6 +9,7 @@
         "price": 124,
         "removalPrice": -102,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.eiffel.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.eiffel.json
@@ -9,6 +9,7 @@
         "price": 204,
         "removalPrice": -168,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.fatbudda.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.fatbudda.json
@@ -9,6 +9,7 @@
         "price": 72,
         "removalPrice": -67,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.giraffe1.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.giraffe1.json
@@ -9,6 +9,7 @@
         "price": 58,
         "removalPrice": -52,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.giraffe2.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.giraffe2.json
@@ -9,6 +9,7 @@
         "price": 58,
         "removalPrice": -52,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.hippo01.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.hippo01.json
@@ -9,6 +9,7 @@
         "price": 64,
         "removalPrice": -56,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.hippo02.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.hippo02.json
@@ -9,6 +9,7 @@
         "price": 64,
         "removalPrice": -56,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.indianst.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.indianst.json
@@ -9,6 +9,7 @@
         "price": 96,
         "removalPrice": -88,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.largeju1.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.largeju1.json
@@ -9,6 +9,7 @@
         "price": 36,
         "removalPrice": 28,
         "cursor": "CURSOR_TREE_DOWN",
+        "isPhotogenic": true,
         "sceneryGroup": "SCGTREES",
         "isTree": true,
         "tiles": [

--- a/objects/rct2ww/scenery_large/rct2.ww.lincolns.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.lincolns.json
@@ -9,6 +9,7 @@
         "price": 134,
         "removalPrice": -114,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.redwood.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.redwood.json
@@ -9,6 +9,7 @@
         "price": 48,
         "removalPrice": 36,
         "cursor": "CURSOR_TREE_DOWN",
+        "isPhotogenic": true,
         "sceneryGroup": "SCGTREES",
         "isTree": true,
         "tiles": [

--- a/objects/rct2ww/scenery_large/rct2.ww.rkreml08.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.rkreml08.json
@@ -9,6 +9,7 @@
         "price": 52,
         "removalPrice": -44,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.rkreml09.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.rkreml09.json
@@ -11,6 +11,7 @@
         "cursor": "CURSOR_HOUSE_DOWN",
         "hasPrimaryColour": true,
         "hasSecondaryColour": true,
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.rkreml10.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.rkreml10.json
@@ -9,6 +9,7 @@
         "price": 56,
         "removalPrice": -48,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.shiva.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.shiva.json
@@ -9,6 +9,7 @@
         "price": 136,
         "removalPrice": -118,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.soflibrt.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.soflibrt.json
@@ -9,6 +9,7 @@
         "price": 260,
         "removalPrice": -190,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.sputnik.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.sputnik.json
@@ -9,6 +9,7 @@
         "price": 114,
         "removalPrice": -82,
         "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.tajmcbse.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.tajmcbse.json
@@ -9,6 +9,7 @@
         "price": 82,
         "removalPrice": -77,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.tajmcolm.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.tajmcolm.json
@@ -9,6 +9,7 @@
         "price": 82,
         "removalPrice": -77,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,

--- a/objects/rct2ww/scenery_large/rct2.ww.tajmctop.json
+++ b/objects/rct2ww/scenery_large/rct2.ww.tajmctop.json
@@ -9,6 +9,7 @@
         "price": 82,
         "removalPrice": -77,
         "cursor": "CURSOR_HOUSE_DOWN",
+        "isPhotogenic": true,
         "tiles": [
             {
                 "x": 0,


### PR DESCRIPTION
This PR updates all of the RCT2 WW large scenery objects to have the following traits:

- They no longer cost $190 to build and give back/remove $150 when demolished. Instead, they now follow a similar cost style to RCT2 Time Twister's large scenery (e.g. the Statue of Liberty now costs $260 to place down and -$190 to remove), with each object having its own build and removal prices.

- Some large scenery objects either now have gained photogenic traits, supports, or both.

- Others have also had their cursor icons changed.

- ja-JP names have been added for the remaining large scenery objects that didn't already have them. Feel free to improve them, though.

I will do a similar update to the small scenery (that will be in a separate PR from this), but that is a whooping **354** objects to do, although I have edited over 75% of them already.