### PR TITLE
Object dump import patch cleaning tool

### DIFF
--- a/language_clean_patch.py
+++ b/language_clean_patch.py
@@ -3,6 +3,29 @@
 from unidiff import PatchSet
 from unidiff.constants import LINE_TYPE_EMPTY
 
+import argparse
+import os
+
+SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
+                       "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
+                       "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+
+def dir_path(string):
+    """ Checks for a valid dir_path """
+    if os.path.isdir(string):
+        return string
+    raise NotADirectoryError(string)
+
+def get_arg_parser():
+    """ Command line arguments """
+    parser = argparse.ArgumentParser(description=\
+                                     'Cleans up a patch file to apply to the objects repository.',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-p', '--patch', required=True, help='Path to the patch file to clean up.')
+    parser.add_argument('-l', '--language', required=True, choices=SUPPORTED_LANGUAGES,\
+                                help='Language that is being translated, e.g. ja-JP')
+    return parser
+
 class PatchCleaner:
     """
     Cleans a given unified diff such that only lines matching the language parameter are included,
@@ -99,5 +122,8 @@ class PatchCleaner:
 
 
 if __name__ == "__main__":
-    patch = PatchCleaner("patch.diff", "nl-NL")
+    parser = get_arg_parser()
+    args = parser.parse_args()
+
+    patch = PatchCleaner(args.patch, args.language)
     print(patch)

--- a/language_clean_patch.py
+++ b/language_clean_patch.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+from unidiff import PatchSet
+from unidiff.constants import (
+    # DEFAULT_ENCODING,
+    LINE_TYPE_ADDED,
+    LINE_TYPE_CONTEXT,
+    LINE_TYPE_EMPTY,
+    LINE_TYPE_REMOVED,
+    # LINE_TYPE_NO_NEWLINE,
+    # LINE_VALUE_NO_NEWLINE,
+    # RE_HUNK_BODY_LINE,
+    # RE_HUNK_EMPTY_BODY_LINE,
+    # RE_HUNK_HEADER,
+    # RE_RENAME_SOURCE_FILENAME,
+    # RE_RENAME_TARGET_FILENAME,
+    # RE_SOURCE_FILENAME,
+    # RE_TARGET_FILENAME,
+    # RE_NO_NEWLINE_MARKER,
+    # RE_BINARY_DIFF,
+)
+
+import os
+import sys
+
+def clean_patch(filename, language):
+    patch = PatchSet.from_filename(filename)
+    files_to_be_removed = []
+    for i, file in enumerate(patch):
+        hunks_to_be_removed = []
+        for j, hunk in enumerate(file):
+            prev_line = None
+            for k, line in enumerate(hunk):
+                # Is this line modifying anything?
+                if line.is_added or line.is_removed:
+                    # We're definitely keeping lines that have something to do
+                    # with the target language.
+                    if language in line.value:
+                        continue
+
+                    # Is this line a removal followed by an addition of the same language,
+                    # in turn followed by the target language?
+                    if line.is_removed and hunk[k + 1].is_added and \
+                        language in hunk[k + 2].value:
+                        # Check languages match
+                        continue
+
+                    # Indeed, is the previous line a removal and the next line an addition
+                    # of the target language?
+                    elif hunk[k - 1].is_removed and line.is_added and \
+                        language in hunk[k + 1].value:
+                        continue
+
+                    # Otherwise, exclude this change from the patch.
+                    else:
+                        line.line_type = LINE_TYPE_EMPTY
+
+
+                prev_line = k
+
+            # Is this hunk still modifying anything?
+            # If not, we'll drop it after iterating everything.
+            if not hunk.added and not hunk.removed:
+                hunks_to_be_removed.append(j)
+
+        # Any hunks to be removed?
+        # (In reverse order, as we'll be reindexing.)
+        if len(hunks_to_be_removed):
+            for j in reversed(hunks_to_be_removed):
+                del file[j]
+
+        if not file.added and not file.removed:
+            files_to_be_removed.append(i)
+
+    # Any files to be removed?
+    # (In reverse order, as we'll be reindexing.)
+    if len(files_to_be_removed):
+        for i in reversed(files_to_be_removed):
+            del patch[i]
+
+    print(patch)
+
+    return patch
+
+
+
+if __name__ == "__main__":
+    clean_patch("patch.diff", "nl-NL")


### PR DESCRIPTION
The object string dumper and loader scripts introduced in #27 have greatly simplified the workflow for object translations. However, the barrier of entry for use by most translators is still too big. Recent work by @tupaschoal has been working towards making an automated workflow, bridging the Objects and Localisation repositories. However, the holdup has been that Python's method of serialising JSON differs in output from what is already present (#93). Rather than writing our own encoder, I propose the following solution. 

I have written a simple Python class, PatchCleaner, that uses the `unidiff` package to disregard changes that arise in patches due to the formatting changes mentioned. In short, this means it only picks up the changes we need. I have added a heuristic to pick up on cases where a trailing comma was added to a line with an irrelevant language. This needs some field testing, but in my brief testing it has worked well.

The workflow is still suboptimal -- and the script doesn't take language and patch file as its arguments yet:
```bash
./language_dump.py -l nl-NL -d nl-NL_dump.json
$EDITOR nl-NL_dump.json
./language_load.py -l nl-NL -i nl-NL_dump.json
git diff > patch.diff
git stash
./language_clean_patch.py | git apply    # no arguments yet, sorry
git commit -m 'Updated object strings for nl-NL'
```

Again, this removes any need for cherry-picking the diff manually. This cherry-picking gets particularly cumbersome for rides and large scenery objects. Indeed, with this script, this workflow can now be completely automated!

As an aside: personally, I like to order the dump files before working on translations. We can avoid complicating `language_dump.py` by using `jq` to this end:
```
jq 'to_entries | sort_by(.value."reference-name") | from_entries' \
    < nl-NL_dump.json \
    > nl-NL_dump.json
```