### PR TITLE
Add shelter to Wacky Worlds Submarines

### DIFF
--- a/objects/rct2ww/ride/rct2.ww.hipporid.json
+++ b/objects/rct2ww/ride/rct2.ww.hipporid.json
@@ -11,6 +11,7 @@
             "gentle",
             "water"
         ],
+        "hasShelter": true,
         "noCollisionCrashes": true,
         "carColours": [
             [

--- a/objects/rct2ww/ride/rct2.ww.killwhal.json
+++ b/objects/rct2ww/ride/rct2.ww.killwhal.json
@@ -78,7 +78,7 @@
             "ru-RU": "Люди плывут в субмарине по подводной трассе"
         },
         "capacity": {
-            "en-GB": "5 passengers per car",
+            "en-GB": "5 passengers per submarine",
             "fr-FR": "5 passagers par sous-marin",
             "de-DE": "5 pro Wagen",
             "es-ES": "pasajeros por vehículo",

--- a/objects/rct2ww/ride/rct2.ww.killwhal.json
+++ b/objects/rct2ww/ride/rct2.ww.killwhal.json
@@ -11,6 +11,7 @@
             "gentle",
             "water"
         ],
+        "hasShelter": true,
         "noCollisionCrashes": true,
         "carColours": [
             [


### PR DESCRIPTION
Although the regular Submarine Ride vehicles were given the hasShelter property in the OpenRCT2 0.2.3 release, the Hippo Submarines and Killer Whale Submarines vehicles from Wacky Worlds were not given said properties. This PR fixes that by adding hasShelter properties to both the Hippo and Killer Whale vehicles for the Submarine Ride. It also adds a minor fix to the Killer Whale Submarines' English capacity description by replacing "car" with "submarine" for consistency with other Submarine Ride vehicles.