### PR TITLE
Add Asian Gong to Asia Themeing scenery group

### DIFF
--- a/objects/rct2ww/scenery_group/rct2.ww.scgasia.json
+++ b/objects/rct2ww/scenery_group/rct2.ww.scgasia.json
@@ -39,6 +39,7 @@
             "GOODSAM",
             "GWOCTUR1",
             "GWOCTUR2",
+            "ORIEGONG",
             "TALLLAN1",
             "TALLLAN2",
             "TERRARMY",


### PR DESCRIPTION
The Asian Gong small object (ORIEGONG) would always show up in the Miscellaneous Objects group, even if the Asia Themeing scenery group was available with all of its listed objects available. This is an issue that originated in RCT2 vanilla and has persisted in RCT Classic and OpenRCT2 until now. This PR fixes the issue by adding the Asian Gong object to the Asia Themeing scenery group. Note that any scenarios using the Asia Themeing that don't already have the Asian Gong object available in the scenario (e.g. Asia - Maharaja Palace) will still need to have said object re-added manually to the scenario with the Object selection feature during gameplay.