### PR TITLE
Complete German translation for Panda stuff

### DIFF
--- a/objects/official/wall/official.mg-prar/object.json
+++ b/objects/official/wall/official.mg-prar/object.json
@@ -52,6 +52,7 @@
     "strings": {
         "name": {
             "en-GB": "Wall with Passageway",
+            "de-DE": "Mauer mit Durchgang",
             "hu-HU": "Fal átjáróval",
             "pt-BR": "Parede com Passagem",
             "nl-NL": "Muur met doorgang",


### PR DESCRIPTION
This completes the German translation for all Panda-related stuff. It turns out most strings were already translated, so only 1 string was missing.

See also: https://github.com/OpenRCT2/Localisation/issues/2005