### PR TITLE
Centralise list of supported languages

### DIFF
--- a/language_clean_patch.py
+++ b/language_clean_patch.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 
+from languages import SUPPORTED_LANGUAGES
 from unidiff import PatchSet
 from unidiff.constants import LINE_TYPE_EMPTY
 
 import argparse
 import os
-
-SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
-                       "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
-                       "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
 
 def dir_path(string):
     """ Checks for a valid dir_path """

--- a/language_dump.py
+++ b/language_dump.py
@@ -10,9 +10,7 @@ import os
 import sys
 # from pprint import pprint
 
-SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
-                       "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
-                       "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+from languages import SUPPORTED_LANGUAGES
 
 def dir_path(string):
     """ Checks for a valid dir_path """

--- a/language_load.py
+++ b/language_load.py
@@ -10,9 +10,7 @@ import os
 import re
 import sys
 
-SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
-                       "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
-                       "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+from languages import SUPPORTED_LANGUAGES
 
 def dir_path(string):
     """ Checks for a valid dir_path """

--- a/languages.py
+++ b/languages.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
+                       "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
+                       "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]

--- a/languages.py
+++ b/languages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 
-SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "es-ES",\
-                       "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO", "nl-NL",\
-                       "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]
+SUPPORTED_LANGUAGES = ["ar-EG", "ca-ES", "cs-CZ", "da-DK", "de-DE", "en-GB", "en-US", "eo-OO",\
+                       "es-ES", "fi-FI", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "nb-NO",\
+                       "nl-NL", "pl-PL", "pt-BR", "ru-RU", "sv-SE", "tr-TR", "zh-CN", "zh-TW"]


### PR DESCRIPTION
This centralises the list of supported languages into one file. Nowhere near a proper package, but at least makes it easier to edit.

I have also added eo-OO to the list of supported languages.