### PR TITLE
Script for verifying json file syntax

### DIFF
--- a/language_verify.sh
+++ b/language_verify.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Exit on error.
+set -e
+
+# We will need some directions... Let's make sure we get them.
+if [ $# -ne 1 ] || [ ! -d $1 ];
+    then echo "Usage: $0 <directory>"
+	exit
+fi
+
+# Traverse input directory, and verify syntax in all files is correct.
+find $1 -type f -name '*.json' | {
+    while read -r f;
+    do jq empty "$f" || echo "in $f";
+    done
+}

--- a/language_verify.sh
+++ b/language_verify.sh
@@ -6,7 +6,7 @@ set -e
 # We will need some directions... Let's make sure we get them.
 if [ $# -ne 1 ] || [ ! -d $1 ];
     then echo "Usage: $0 <directory>"
-	exit
+    exit
 fi
 
 # Traverse input directory, and verify syntax in all files is correct.


### PR DESCRIPTION
This PR introduces a shell script to quickly verify the syntax for all JSON files in the directory specified. The idea is to have this script run as a CI Action on PRs, both on the objects and Localisation repositories.

Usage example:
```
$ ./language_verify.sh objects/
```

Expected behaviour is to not have any output if no syntax errors are present. If an error is introduced, an error message will be printed as follows:

```
$ ./language_verify.sh objects/rct2ww/ride/
parse error: Expected separator between values at line 5, column 16
in objects/rct2ww/ride/rct2.ww.anaconda.json
```