### PR TITLE
de-DE: Replace ASCII apostrophes

### DIFF
--- a/objects/rct2/scenery_small/rct2.tvl.json
+++ b/objects/rct2/scenery_small/rct2.tvl.json
@@ -18,7 +18,7 @@
         "name": {
             "en-GB": "Voss's Laburnam Tree",
             "fr-FR": "Arbre de Voss Laburnam",
-            "de-DE": "Voss' Goldregenbaum",
+            "de-DE": "Voss’ Goldregenbaum",
             "es-ES": "Labiérnago de Voss",
             "it-IT": "Laburno di Voss",
             "nl-NL": "Goudenregenboom",

--- a/objects/rct2tt/park_entrance/rct2.tt.gldyrent.json
+++ b/objects/rct2tt/park_entrance/rct2.tt.gldyrent.json
@@ -14,7 +14,7 @@
         "name": {
             "en-GB": "Rock 'n' Roll Park Entrance",
             "fr-FR": "Entrée du parc Rock & Roll",
-            "de-DE": "Rock-'n'-Roll-Parkeingang",
+            "de-DE": "Rock-’n’-Roll-Parkeingang",
             "es-ES": "Entrada al parque del Rock & Roll",
             "it-IT": "Entrata del Parco Rock & Roll",
             "nl-NL": "Parkingang in 'rock 'n roll'-stijl",

--- a/objects/rct2tt/scenery_group/rct2.tt.scg1960s.json
+++ b/objects/rct2tt/scenery_group/rct2.tt.scg1960s.json
@@ -54,7 +54,7 @@
         "name": {
             "en-GB": "Rock 'n' Roll Themeing",
             "fr-FR": "Thème du Rock & Roll",
-            "de-DE": "Rock-'n'-Roll-Thema",
+            "de-DE": "Rock-’n’-Roll-Thema",
             "es-ES": "Tema rock & roll",
             "it-IT": "Tema Rock & Roll",
             "nl-NL": "'Rock 'n roll'-thema",


### PR DESCRIPTION
This replaces ASCII apostrophes in the German translation with U+2019.

See also: https://github.com/OpenRCT2/Localisation/issues/2121