### PR TITLE
Update corkscrew & junior trains for RCT1/Classic Parity

### DIFF
--- a/objects/official/ride/rct2.dlc.zpanda/object.json
+++ b/objects/official/ride/rct2.dlc.zpanda/object.json
@@ -12,7 +12,7 @@
         "category": "rollercoaster",
         "noInversions": true,
         "minCarsPerTrain": 4,
-        "maxCarsPerTrain": 12,
+        "maxCarsPerTrain": 15,
         "numEmptyCars": 2,
         "tabCar": 1,
         "headCars": 1,

--- a/objects/rct2/ride/rct2.arrt1.json
+++ b/objects/rct2/ride/rct2.arrt1.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2/ride/rct2.zldb.json
+++ b/objects/rct2/ride/rct2.zldb.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "noInversions": true,
         "minCarsPerTrain": 5,
-        "maxCarsPerTrain": 12,
+        "maxCarsPerTrain": 15,
         "numEmptyCars": 2,
         "tabCar": 1,
         "defaultCar": 1,

--- a/objects/rct2/ride/rct2.zlog.json
+++ b/objects/rct2/ride/rct2.zlog.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "noInversions": true,
         "minCarsPerTrain": 5,
-        "maxCarsPerTrain": 12,
+        "maxCarsPerTrain": 15,
         "numEmptyCars": 2,
         "tabCar": 1,
         "defaultCar": 1,

--- a/objects/rct2ww/ride/rct2.ww.bullet.json
+++ b/objects/rct2ww/ride/rct2.ww.bullet.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2ww/ride/rct2.ww.caddilac.json
+++ b/objects/rct2ww/ride/rct2.ww.caddilac.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2ww/ride/rct2.ww.congaeel.json
+++ b/objects/rct2ww/ride/rct2.ww.congaeel.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2ww/ride/rct2.ww.dragon.json
+++ b/objects/rct2ww/ride/rct2.ww.dragon.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2ww/ride/rct2.ww.gratwhte.json
+++ b/objects/rct2ww/ride/rct2.ww.gratwhte.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2ww/ride/rct2.ww.seals.json
+++ b/objects/rct2ww/ride/rct2.ww.seals.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 8,
+        "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/objects/rct2ww/ride/rct2.ww.whicgrub.json
+++ b/objects/rct2ww/ride/rct2.ww.whicgrub.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "noInversions": true,
         "minCarsPerTrain": 5,
-        "maxCarsPerTrain": 12,
+        "maxCarsPerTrain": 15,
         "numEmptyCars": 2,
         "tabCar": 1,
         "defaultCar": 1,


### PR DESCRIPTION
In RCT1 the corkscrew coaster trains have can have 8 cars per train.
In RCT Classic both of the junior coaster trains can have 13 cars per train.

This PR raises the limits of these trains to have parity with their RCT1/Classic counterparts.
Additionally it also raises the limits of the WW/DLC corkscrew/junior trains for consistency

![rct1corkscrew](https://user-images.githubusercontent.com/42477864/117422531-b14c9380-aeed-11eb-89e1-1f07f0067a91.png)
![rctclassicjrc](https://user-images.githubusercontent.com/42477864/117422533-b1e52a00-aeed-11eb-8166-75ae001224ff.png)

