### PR TITLE
Update mini suspended lay-down cars for RCT1 Parity

### DIFF
--- a/objects/rct2/ride/rct2.ride.skytr.json
+++ b/objects/rct2/ride/rct2.ride.skytr.json
@@ -8,6 +8,8 @@
     "properties": {
         "type": "mini_suspended_rc",
         "category": "rollercoaster",
+        "minCarsPerTrain": 1,
+        "maxCarsPerTrain": 2,
         "ratingMultipler": {
             "excitement": 10,
             "intensity": 25,


### PR DESCRIPTION
The mini suspended coaster's lay-down cars can have 2 cars per train in RCT1.
This PR raises the limit of this train to 2 for parity with it's RCT1 counterpart.
![rct1laydowncars](https://user-images.githubusercontent.com/42477864/118863457-e7eeba80-b8ac-11eb-9867-55086935addb.png)
