### PR TITLE
Implement extra fairground music tracks CSS10/CSS16

### DIFF
--- a/objects/rct2/music/rct2.music.fairground.json
+++ b/objects/rct2/music/rct2.music.fairground.json
@@ -39,6 +39,11 @@
                 "composer": "Traditional"
             },
             {
+                "source": "$RCT2:DATA/css10.dat",
+                "name": "Stars And Stripes Forever",
+                "composer": "John Philip Sousa"
+            },
+            {
                 "source": "$RCT2:DATA/css11.dat",
                 "name": "Das Alpenhorn",
                 "composer": "Traditional"
@@ -62,6 +67,11 @@
                 "source": "$RCT2:DATA/css15.dat",
                 "name": "Waltz Medley",
                 "composer": "Johann Strauss jr."
+            },
+            {
+                "source": "$RCT2:DATA/css16.dat",
+                "name": "Petersburger Schlittenfahrt",
+                "composer": "Richard Eilenberg"
             }
         ]
     },


### PR DESCRIPTION
Implements extra fairground music tracks in css10.dat & css16.dat if they are provided by the user.
So this way the user can provide the missing fairground tracks if they would like to have them, More info in the below link.
https://forums.openrct2.org/topic/5557-missing-music-css10dat-css16dat/
So nighthawk did make the metadata for this as gymnasiast told me to use it.
But i went ahead and tested it to make sure it worked properly when the user has the vanilla blank css10/16 dats:
Openrct2 will safely ignore the blank dats when randomly choosing a track to play.
The music on the ride will also be reset if loading a save with css10/16 playing with the vanilla blank dats.

Gymnasiast also mentioned that this behavior was present in RCT1 so in a way this technically makes this an RCT1 parity improvement.