### PR TITLE
Make RCT1's tarmac work for everyone.

### DIFF
--- a/objects/rct1/footpath_surface/rct1.footpath_surface.tarmac/object.json
+++ b/objects/rct1/footpath_surface/rct1.footpath_surface.tarmac/object.json
@@ -9,7 +9,9 @@
     },
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },
-        "$CSG[43371..43421]"
+        "$RCT2:OBJDATA/TARMAC.DAT[0..15]",
+        "$RCT2:OBJDATA/ROAD.DAT[16..19]",
+        "$RCT2:OBJDATA/TARMAC.DAT[20..50]"
     ],
     "strings": {
         "name": {


### PR DESCRIPTION
rct2's road path surface is the only rct2 path surface that has slopes instead of stairs.
They are identical to rct1's tarmac slopes along with rct2's tarmac paths also being identical.
So this fix simply makes the rct1 tarmac path surface use these sprites allowing it to be used without rct1.