### PR TITLE
Fix WW connecting double sided walls

### DIFF
--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.tmarch1.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.tmarch1.json
@@ -6,10 +6,14 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isDoubleSided": true,
         "height": 8,
         "price": 50
     },
-    "images": ["$RCT2:OBJDATA/TMARCH1.DAT[0..5]"],
+    "images": [
+        "$RCT2:OBJDATA/TMARCH2.DAT[0..5]",
+        "$RCT2:OBJDATA/TMARCH1.DAT[0..5]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Maharaja Palace Arch 1",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.tmarch2.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.tmarch2.json
@@ -6,10 +6,14 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isDoubleSided": true,
         "height": 8,
         "price": 50
     },
-    "images": ["$RCT2:OBJDATA/TMARCH2.DAT[0..5]"],
+    "images": [
+        "$RCT2:OBJDATA/TMARCH1.DAT[0..5]",
+        "$RCT2:OBJDATA/TMARCH2.DAT[0..5]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Maharaja Palace Arch 2",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wtudor03.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wtudor03.json
@@ -6,11 +6,25 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isDoubleSided": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50
     },
-    "images": ["$RCT2:OBJDATA/WTUDOR03.DAT[0..5]"],
+    "images": [
+        "$RCT2:OBJDATA/WTUDOR04.DAT[0]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[1]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[2]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[3]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[4]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[5]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[0]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[1]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[2]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[3]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[4]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[5]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Tudor Ground Floor Wall Piece 3",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wtudor04.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wtudor04.json
@@ -6,11 +6,25 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isDoubleSided": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50
     },
-    "images": ["$RCT2:OBJDATA/WTUDOR04.DAT[0..5]"],
+    "images": [
+        "$RCT2:OBJDATA/WTUDOR03.DAT[0]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[1]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[2]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[3]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[4]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[5]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[0]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[1]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[2]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[3]",
+        "$RCT2:OBJDATA/WTUDOR04.DAT[4]",
+        "$RCT2:OBJDATA/WTUDOR03.DAT[5]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Tudor Ground Floor Wall Piece 4",


### PR DESCRIPTION
This fixes the maharaja arch pieces & the connecting tudor walls.
As they were not set up as double sided walls so their sprites would change depending on viewing angle.
So i have given them all the isDoubleSided flag and also re-ordered their sprites accordingly.
The maharaja arch pieces were relatively simple to fix and just required referencing the opposite arch's sprites.
The tudor walls were really messed up as they included the wrong sprites so i've completely redone their sprite order to fix that.
For both of them i did have to swap the sprites around to keep the outside sprites the same.
(ex: tmarch1 starts with tmarch2's sprites and vice versa)
Compatibility wise the maharaja gates aren't affected too much, The maharaja palace scenario from wacky worlds looks fine with them after the change, However the inside sprites are different so any parks that used them like that will look incorrect
As for the tudor walls they will technically be different now as they had to be drastically re-ordered but even then the objects themselves were broken to begin with so it's not like builders had much control over them in the first place.

![NSF Testing Land 2021-06-05 16-09-24](https://user-images.githubusercontent.com/42477864/120904483-82276000-c61a-11eb-8c1b-c144401a7b60.png)
![NSF Testing Land 2021-06-05 16-09-26](https://user-images.githubusercontent.com/42477864/120904485-89e70480-c61a-11eb-821d-0b3172d5d02c.png)

