### PR TITLE
Add RCT1/AA/LL music source games.

### DIFF
--- a/objects/rct2/music/rct2.music.custom1.json
+++ b/objects/rct2/music/rct2.music.custom1.json
@@ -3,7 +3,7 @@
     "authors": [],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC23|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 23,

--- a/objects/rct2/music/rct2.music.custom2.json
+++ b/objects/rct2/music/rct2.music.custom2.json
@@ -3,7 +3,7 @@
     "authors": [],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC24|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 24,

--- a/objects/rct2/music/rct2.music.dodgems.json
+++ b/objects/rct2/music/rct2.music.dodgems.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC00|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 0,

--- a/objects/rct2/music/rct2.music.egyptian.json
+++ b/objects/rct2/music/rct2.music.egyptian.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC06|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 6,

--- a/objects/rct2/music/rct2.music.fairground.json
+++ b/objects/rct2/music/rct2.music.fairground.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC01|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1"],
     "objectType": "music",
     "properties": {
         "rideTypes": ["merry_go_round"],

--- a/objects/rct2/music/rct2.music.fantasy.json
+++ b/objects/rct2/music/rct2.music.fantasy.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC19|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 19,

--- a/objects/rct2/music/rct2.music.gentle.json
+++ b/objects/rct2/music/rct2.music.gentle.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC12|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 12,

--- a/objects/rct2/music/rct2.music.horror.json
+++ b/objects/rct2/music/rct2.music.horror.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC10|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 10,

--- a/objects/rct2/music/rct2.music.ice.json
+++ b/objects/rct2/music/rct2.music.ice.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC21|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 21,

--- a/objects/rct2/music/rct2.music.jungle.json
+++ b/objects/rct2/music/rct2.music.jungle.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC05|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 5,

--- a/objects/rct2/music/rct2.music.jurassic.json
+++ b/objects/rct2/music/rct2.music.jurassic.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC16|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 16,

--- a/objects/rct2/music/rct2.music.martian.json
+++ b/objects/rct2/music/rct2.music.martian.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC04|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 4,

--- a/objects/rct2/music/rct2.music.medieval.json
+++ b/objects/rct2/music/rct2.music.medieval.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC25|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 25,

--- a/objects/rct2/music/rct2.music.oriental.json
+++ b/objects/rct2/music/rct2.music.oriental.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC03|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 3,

--- a/objects/rct2/music/rct2.music.ragtime.json
+++ b/objects/rct2/music/rct2.music.ragtime.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC18|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 18,

--- a/objects/rct2/music/rct2.music.rock1.json
+++ b/objects/rct2/music/rct2.music.rock1.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC17|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 17,

--- a/objects/rct2/music/rct2.music.rock2.json
+++ b/objects/rct2/music/rct2.music.rock2.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC20|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 20,

--- a/objects/rct2/music/rct2.music.roman.json
+++ b/objects/rct2/music/rct2.music.roman.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC02|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 2,

--- a/objects/rct2/music/rct2.music.snow.json
+++ b/objects/rct2/music/rct2.music.snow.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC22|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 22,

--- a/objects/rct2/music/rct2.music.space.json
+++ b/objects/rct2/music/rct2.music.space.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC09|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 9,

--- a/objects/rct2/music/rct2.music.summer.json
+++ b/objects/rct2/music/rct2.music.summer.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC13|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 13,

--- a/objects/rct2/music/rct2.music.techno.json
+++ b/objects/rct2/music/rct2.music.techno.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC11|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 11,

--- a/objects/rct2/music/rct2.music.toyland.json
+++ b/objects/rct2/music/rct2.music.toyland.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC07|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 7,

--- a/objects/rct2/music/rct2.music.urban.json
+++ b/objects/rct2/music/rct2.music.urban.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC26|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 26,

--- a/objects/rct2/music/rct2.music.water.json
+++ b/objects/rct2/music/rct2.music.water.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC14|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 14,

--- a/objects/rct2/music/rct2.music.wildwest.json
+++ b/objects/rct2/music/rct2.music.wildwest.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Allister Brimble"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC15|00000000",
-    "sourceGame": ["rct2"],
+    "sourceGame": ["rct2", "rct1aa"],
     "objectType": "music",
     "properties": {
         "originalStyleId": 15,


### PR DESCRIPTION
Should be correct, I simply checked every track on my RCT1, AA, and LL discs to see when new tracks were introduced and added source games accordingly.
The only odd ones are the two custom music tracks as they obviously don't come with the game.
But the CUSTOM.TXT file first appeared in LL so as such i added LL as a source game for the custom music tracks.
I don't have an install of RCT1+AA so i can't test to see if custom tracks were first introduced there but CUSTOM.TXT is not present on my AA disc so i'm doubtful they were introduced in AA.
