### PR TITLE
Add invisible queue

### DIFF
--- a/objects/official/footpath_surface/openrct2.footpath_surface.queue_invisible.json
+++ b/objects/official/footpath_surface/openrct2.footpath_surface.queue_invisible.json
@@ -1,0 +1,18 @@
+{
+  "id": "openrct2.footpath_surface.queue_invisible",
+  "authors": ["OpenRCT2 developers"],
+  "version": "1.0",
+  "sourceGame": ["official"],
+  "objectType": "footpath_surface",
+  "properties": {
+    "isQueue": true
+  },
+  "images": [
+    "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""
+  ],
+  "strings": {
+    "name": {
+      "en-GB": "Invisible queue"
+    }
+  }
+}


### PR DESCRIPTION
Adds an invisible queue path surface to complete the invisible path object trio.
![NSF Sandbox 2021-11-30 08-51-22](https://user-images.githubusercontent.com/42477864/144062359-67bf40b9-a7ab-4cca-9602-9e9aee8b9d62.png)