### PR TITLE
WW Large scenery preview direction fixes

### DIFF
--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.afrclion.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.afrclion.json
@@ -24,7 +24,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/1X2LION.DAT[0..11]"],
+    "images": [
+        "$RCT2:OBJDATA/1X2LION.DAT[1]",
+        "$RCT2:OBJDATA/1X2LION.DAT[2]",
+        "$RCT2:OBJDATA/1X2LION.DAT[3]",
+        "$RCT2:OBJDATA/1X2LION.DAT[0]",
+        "$RCT2:OBJDATA/1X2LION.DAT[4..11]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Lion",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.afrrhino.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.afrrhino.json
@@ -24,7 +24,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/1X2RHINO.DAT[0..11]"],
+    "images": [
+        "$RCT2:OBJDATA/1X2RHINO.DAT[1]",
+        "$RCT2:OBJDATA/1X2RHINO.DAT[2]",
+        "$RCT2:OBJDATA/1X2RHINO.DAT[3]",
+        "$RCT2:OBJDATA/1X2RHINO.DAT[0]",
+        "$RCT2:OBJDATA/1X2RHINO.DAT[4..11]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Rhino",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.afrzebra.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.afrzebra.json
@@ -24,7 +24,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/1X2ZEBRA.DAT[0..11]"],
+    "images": [
+        "$RCT2:OBJDATA/1X2ZEBRA.DAT[1]",
+        "$RCT2:OBJDATA/1X2ZEBRA.DAT[2]",
+        "$RCT2:OBJDATA/1X2ZEBRA.DAT[3]",
+        "$RCT2:OBJDATA/1X2ZEBRA.DAT[0]",
+        "$RCT2:OBJDATA/1X2ZEBRA.DAT[4..11]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Zebra",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.atractor.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.atractor.json
@@ -24,7 +24,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/1X2TRCTR.DAT[0..11]"],
+    "images": [
+        "$RCT2:OBJDATA/1X2TRCTR.DAT[1]",
+        "$RCT2:OBJDATA/1X2TRCTR.DAT[2]",
+        "$RCT2:OBJDATA/1X2TRCTR.DAT[3]",
+        "$RCT2:OBJDATA/1X2TRCTR.DAT[0]",
+        "$RCT2:OBJDATA/1X2TRCTR.DAT[4..11]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Tractor",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.bigdish.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.bigdish.json
@@ -76,7 +76,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/BIGDISH.DAT[0..39]"],
+    "images": [
+        "$RCT2:OBJDATA/BIGDISH.DAT[1]",
+        "$RCT2:OBJDATA/BIGDISH.DAT[2]",
+        "$RCT2:OBJDATA/BIGDISH.DAT[0]",
+        "$RCT2:OBJDATA/BIGDISH.DAT[3]",
+        "$RCT2:OBJDATA/BIGDISH.DAT[4..39]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Satellite Dish",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.gdstaue2.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.gdstaue2.json
@@ -41,7 +41,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/GDSTAUE2.DAT[0..19]"],
+    "images": [
+        "$RCT2:OBJDATA/GDSTAUE2.DAT[0]",
+        "$RCT2:OBJDATA/GDSTAUE2.DAT[2]",
+        "$RCT2:OBJDATA/GDSTAUE2.DAT[3]",
+        "$RCT2:OBJDATA/GDSTAUE2.DAT[1]",
+        "$RCT2:OBJDATA/GDSTAUE2.DAT[4..19]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Gold Statue 2",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.hippo01.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.hippo01.json
@@ -24,7 +24,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/HIPPO01.DAT[0..11]"],
+    "images": [
+        "$RCT2:OBJDATA/HIPPO01.DAT[1]",
+        "$RCT2:OBJDATA/HIPPO01.DAT[2]",
+        "$RCT2:OBJDATA/HIPPO01.DAT[3]",
+        "$RCT2:OBJDATA/HIPPO01.DAT[0]",
+        "$RCT2:OBJDATA/HIPPO01.DAT[4..11]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Hippo 1",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.hippo02.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.hippo02.json
@@ -24,7 +24,13 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/HIPPO02.DAT[0..11]"],
+    "images": [
+        "$RCT2:OBJDATA/HIPPO02.DAT[1]",
+        "$RCT2:OBJDATA/HIPPO02.DAT[2]",
+        "$RCT2:OBJDATA/HIPPO02.DAT[3]",
+        "$RCT2:OBJDATA/HIPPO02.DAT[0]",
+        "$RCT2:OBJDATA/HIPPO02.DAT[4..11]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Hippo 2",


### PR DESCRIPTION
Fixes some of WW's large scenery items facing the wrong direction in their previews, Now they properly match up with the actual item you're placing.
![DeepinScreenshot_select-area_20211208112016](https://user-images.githubusercontent.com/42477864/145246390-0d1ff21f-25f1-4ad4-b63f-7a7b37578a43.png)
