### PR TITLE
Improve yellow bamboo fallback images

### DIFF
--- a/objects/rct1/footpath_railings/rct1ll.footpath_railings.bamboo/object.json
+++ b/objects/rct1/footpath_railings/rct1ll.footpath_railings.bamboo/object.json
@@ -20,7 +20,9 @@
     ],
     "noCsgImages": [
         { "path": "preview.png", "x": 1, "y": 1 },
-        "$RCT2:OBJDATA/PATHDIRT.DAT[73..145]"
+        "$RCT2:OBJDATA/PATHDIRT.DAT[73..108]",
+        "$G1[3445..3464]",
+        "$G1[3658..3674]"
     ],
     "strings": {
         "name": {


### PR DESCRIPTION
Makes the yellow bamboo railing fallback images use some leftover rct1 sprites from g1 alongside some sprites from the brown bamboo railings.
It's not perfect but i think it's about as close as we can get without having rct1 linked.
How the current fallback images look
![norct1-current](https://user-images.githubusercontent.com/42477864/146081042-76ee6af2-4433-4135-961f-4c735cd5e40e.png)
How the new fallback images from this PR look
![norct1-new](https://user-images.githubusercontent.com/42477864/146081063-cd6b9c85-fc4c-4fc0-be94-095648dc0c51.png)
How it should look with RCT1 linked
![rct1-normal](https://user-images.githubusercontent.com/42477864/146081097-77b4caf3-2813-41e7-a13e-e441cac5f32e.png)

