### PR TITLE
WW/TT Small scenery rotation direction fixes

### DIFF
--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.wiskybl2.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.wiskybl2.json
@@ -17,7 +17,12 @@
         "isStackable": true,
         "prohibitWalls": true
     },
-    "images": ["$RCT2:OBJDATA/WISKYBL2.DAT[0..3]"],
+    "images": [
+        "$RCT2:OBJDATA/WISKYBL2.DAT[0]",
+        "$RCT2:OBJDATA/WISKYBL2.DAT[2]",
+        "$RCT2:OBJDATA/WISKYBL2.DAT[1]",
+        "$RCT2:OBJDATA/WISKYBL2.DAT[3]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Whisky Barrels",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt1.json
@@ -15,7 +15,12 @@
         "hasPrimaryColour": true,
         "isStackable": true
     },
-    "images": ["$RCT2:OBJDATA/TNT1.DAT[0..3]"],
+    "images": [
+        "$RCT2:OBJDATA/TNT1.DAT[0]",
+        "$RCT2:OBJDATA/TNT1.DAT[2]",
+        "$RCT2:OBJDATA/TNT1.DAT[1]",
+        "$RCT2:OBJDATA/TNT1.DAT[3]"
+    ],
     "strings": {
         "name": {
             "en-GB": "TNT Stack",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt2.json
@@ -15,7 +15,12 @@
         "hasPrimaryColour": true,
         "isStackable": true
     },
-    "images": ["$RCT2:OBJDATA/TNT2.DAT[0..3]"],
+    "images": [
+        "$RCT2:OBJDATA/TNT2.DAT[0]",
+        "$RCT2:OBJDATA/TNT2.DAT[2]",
+        "$RCT2:OBJDATA/TNT2.DAT[1]",
+        "$RCT2:OBJDATA/TNT2.DAT[3]"
+    ],
     "strings": {
         "name": {
             "en-GB": "TNT Barrels",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt3.json
@@ -15,7 +15,12 @@
         "hasPrimaryColour": true,
         "isStackable": true
     },
-    "images": ["$RCT2:OBJDATA/TNT3.DAT[0..3]"],
+    "images": [
+        "$RCT2:OBJDATA/TNT3.DAT[0]",
+        "$RCT2:OBJDATA/TNT3.DAT[2]",
+        "$RCT2:OBJDATA/TNT3.DAT[1]",
+        "$RCT2:OBJDATA/TNT3.DAT[3]"
+    ],
     "strings": {
         "name": {
             "en-GB": "TNT Detonator",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt4.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt4.json
@@ -15,7 +15,12 @@
         "hasPrimaryColour": true,
         "isStackable": true
     },
-    "images": ["$RCT2:OBJDATA/TNT4.DAT[0..3]"],
+    "images": [
+        "$RCT2:OBJDATA/TNT4.DAT[0]",
+        "$RCT2:OBJDATA/TNT4.DAT[2]",
+        "$RCT2:OBJDATA/TNT4.DAT[1]",
+        "$RCT2:OBJDATA/TNT4.DAT[3]"
+    ],
     "strings": {
         "name": {
             "en-GB": "TNT Crates",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wnauti05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wnauti05.json
@@ -15,7 +15,12 @@
         "isStackable": true,
         "hasNoSupports": true
     },
-    "images": ["$RCT2:OBJDATA/WNAUTI05.DAT[0..3]"],
+    "images": [
+        "$RCT2:OBJDATA/WNAUTI05.DAT[0]",
+        "$RCT2:OBJDATA/WNAUTI05.DAT[3]",
+        "$RCT2:OBJDATA/WNAUTI05.DAT[1]",
+        "$RCT2:OBJDATA/WNAUTI05.DAT[2]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Nautical Roof Piece",


### PR DESCRIPTION
Fixes the rotations of a few small scenery pieces from WW/TT that would face different directions depending on the viewing angle due to them having messed up sprite orders.
The fixed objects are:

TNT set from the africa theming
Whisky Barrels from the roaring twenties theming
Nautical roof piece 5 from the australasian theming

This will technically change the look of parks that already used these objects but i feel like it is such a subtle change it shouldn't ruin the look of any pre-existing parks and will give users more control over these items so they can be better utilized for future parks.

Here's some screenshots demonstrating the fix.
First sprite (sprite 0) for all objects is unchanged.
![first](https://user-images.githubusercontent.com/42477864/160134672-c817f11c-f97f-4e05-81ab-8fc99aa379ef.png)
Old sprite order (not facing proper directions compared to the first screenshot, most notably on the tnt detonator, whisky barrels, and nautical roof piece 5)
![old](https://user-images.githubusercontent.com/42477864/160134868-3c2882ba-3064-49e5-bfd2-95682dc49b2f.png)
Fixed sprite order (now facing proper directions compared to the first screenshot)
![fixed](https://user-images.githubusercontent.com/42477864/160135008-a98beb27-d909-4f8c-95b7-6d12012f3c63.png)

