### PR TITLE
Add entertainer costumes to WW scenery groups

### DIFF
--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgafric.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgafric.json
@@ -112,7 +112,8 @@
             "rct2ww.scenery_large.3x3atre3",
             "rct2ww.scenery_large.3x3altre"
         ],
-        "priority": 25
+        "priority": 25,
+        "entertainerCostumes": "gorilla"
     },
     "images": ["$RCT2:OBJDATA/SCGAFRIC.DAT[0..1]"],
     "strings": {

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgartic.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgartic.json
@@ -54,7 +54,8 @@
             "rct2ww.scenery_small.pva",
             "rct2ww.scenery_large.sunken"
         ],
-        "priority": 25
+        "priority": 25,
+        "entertainerCostumes": "snowman"
     },
     "images": ["$RCT2:OBJDATA/SCGARTIC.DAT[0..1]"],
     "strings": {

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgnamrc.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgnamrc.json
@@ -121,7 +121,11 @@
             "rct2ww.scenery_large.1x4brg04",
             "rct2ww.scenery_large.1x4brg05"
         ],
-        "priority": 25
+        "priority": 25,
+        "entertainerCostumes": [
+            "bandit",
+            "sheriff"
+        ]
     },
     "images": ["$RCT2:OBJDATA/SCGNAMRC.DAT[0..1]"],
     "strings": {


### PR DESCRIPTION
The time twister scenery groups enable extra entertainer costumes so why not do the same for wacky worlds' scenery groups?
Sure it's not the biggest thing but a little QoL improvement to make it consistent with the other pack's scenery groups.

Africa Theming: Gorilla Costume
The african style of WW comes with gorilla themed coaster cars along with the scenery group providing a ton of jungle flora so i think it'd make sense for the scenery group to provide the gorilla costume.

Antarctic Theming: Snowman Costume
The antarctic style of WW has a lot of snow/ice themed content so i don't think it'd hurt for it's scenery group to provide the snowman costume.

North America Theming: Bandit & Sheriff Costumes
The north american theming comes with some giant cowboy statues among other wild west themed scenery so i think it'd make sense for it to provide these entertainer costumes.
![DeepinScreenshot_select-area_20220328231101](https://user-images.githubusercontent.com/42477864/160525758-74ebe351-d238-48a3-8f10-5588ef02b5b2.png)

