### PR TITLE
WWTT Train default color fixes

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
+++ b/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
@@ -12,10 +12,7 @@
         "maxCarsPerTrain": 3,
         "carColours": [
             [
-                ["black", "light_orange", "light_orange"]
-            ],
-            [
-                ["light_purple", "bright_red", "black"]
+                ["black", "black", "light_brown"]
             ]
         ],
         "cars": {

--- a/objects/rct2ww/ride/rct2ww.ride.condorrd.json
+++ b/objects/rct2ww/ride/rct2ww.ride.condorrd.json
@@ -16,7 +16,7 @@
                 ["bright_red", "yellow", "dark_purple"]
             ],
             [
-                ["teal", "grey", "black"]
+                ["teal", "grey", "dark_purple"]
             ]
         ],
         "cars": [

--- a/objects/rct2ww/ride/rct2ww.ride.taxicstr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.taxicstr.json
@@ -18,13 +18,7 @@
         "tailCars": 2,
         "carColours": [
             [
-                ["white", "bright_red", "yellow"]
-            ],
-            [
-                ["bright_red", "dark_green", "black"]
-            ],
-            [
-                ["yellow", "black", "bright_red"]
+                ["black", "black", "yellow"]
             ]
         ],
         "cars": [


### PR DESCRIPTION
Fixes the default colors of three WW/TT trains as they have improper third colors, along with removing some useless default color presets for the taxi & valkyrie trains as those trains are not changed by the first/second colors and thus, the additional presets do nothing.
This only fixes new instances of these trains in parks and track designs, any old parks or track designs with these trains will still use the old colors until the train is re-selected from the ride's trains tab.

Yellow Taxis: Removed two presets, default first/second colors are now black and the default third color is now yellow, this is the most blatant one as the third color is prominently used on the vehicles and looks really bad if it's not yellow.
Condors: Default third color for both presets is now dark purple, probably the most subtle one of the three as it's just a few stray pixels on a few of the sprites.
Valkyries: Removed one preset, default first/second colors are now black and the default third color is now light brown, the third color only partially recolors the hair and light brown seems like the intended color for it.

Screenshot only has all colors enabled for demonstration purposes, available color flags weren't touched at all for this PR so the third colors will remain hidden.
![DeepinScreenshot_select-area_20220329180136](https://user-images.githubusercontent.com/42477864/160716938-7de1eb6a-c4d9-4f5b-a1b6-6d31b13c5548.png)

