### PR TITLE
RCT2 Path source game fixes

### DIFF
--- a/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_black/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_black/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_railings.bamboo_black",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_railings",
     "properties": {
         "supportType": "pole",

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_brown/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_brown/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_railings.bamboo_brown",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_railings",
     "properties": {
         "supportType": "pole",

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.space/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.space/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_railings.space",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_railings",
     "properties": {
         "supportType": "pole",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.ash/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.ash/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.ash",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.crazy_paving/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.crazy_paving/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.crazy_paving",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.dirt/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.dirt/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.dirt",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.tarmac",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_brown/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_brown/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.tarmac_brown",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_green/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_green/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.tarmac_green",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_red/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_red/object.json
@@ -2,7 +2,7 @@
     "id": "rct2.footpath_surface.tarmac_red",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": "rct2",
     "objectType": "footpath_surface",
     "images": [
         { "path": "preview.png", "x": 1, "y": 1 },


### PR DESCRIPTION
Removes some outdated rct1/rct1aa source games from the rct2 path objects.
As the actual rct1 path objects have been introduced and thus, the rct2 paths should not have rct1 in their source games.
I kept the road, gray-brown concrete, and wooden supports source games intact as they do not have rct1 counterparts.