### PR TITLE
Maharaja Steam Train Fixes

### DIFF
--- a/objects/rct2ww/ride/rct2ww.ride.steamtrn.json
+++ b/objects/rct2ww/ride/rct2ww.ride.steamtrn.json
@@ -9,6 +9,7 @@
         "type": "miniature_railway",
         "category": "transport",
         "tabScale": 0.5,
+        "hasShelter": true,
         "playDepartSound": true,
         "noCollisionCrashes": true,
         "minCarsPerTrain": 3,
@@ -19,9 +20,6 @@
             0,
             1
         ],
-        "ratingMultipler": {
-            "excitement": 3
-        },
         "carColours": [
             [
                 ["yellow", "bordeaux_red", "bright_yellow"]
@@ -69,7 +67,6 @@
                     "gentleSlopes": true,
                     "diagonalSlopes": true
                 },
-                "isPoweredRideWithUnrestrictedGravity": true,
                 "hasAdditionalColour1": true,
                 "isPowered": true
             },


### PR DESCRIPTION
During WW's development frontier seems to have cloned this train from the open air cars version of the steam train rather than the covered cars version despite the maharaja train cars clearly being covered. (it even says this in their description)
Additionally they somehow managed to put the "isPoweredRideWithUnrestrictedGravity" flag onto the second car (the train's coal-car) which no other railway train has, it doesn't have much of an effect on the train as only this car has it but it still certainly doesn't belong there.
So i have applied the "hasShelter" flag to them, removed the 3% excitement rating multiplier, and removed the unrestricted gravity flag from the coal-car, which should make these trains more in line with the covered cars version of the base game steam train.