### PR TITLE
Fix 1920s Racing Cars getting stuck

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.1920racr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.1920racr.json
@@ -46,7 +46,7 @@
         ],
         "cars": {
             "rotationFrameMask": 31,
-            "spacing": 274912,
+            "spacing": 209100,
             "mass": 250,
             "numSeats": 1,
             "numSeatRows": 1,


### PR DESCRIPTION
The 1920s racing cars from TT can get stuck after a while due to them having a larger spacing value than the vanilla go karts.
To fix this i decreased the spacing value of them from 274912 to 209100 which seems to have stopped them from getting stuck.
I chose this number as numbers around 213000 will cause them to frequently bump into eachother slowing down throughput by a lot and values higher than 223000 will cause them to start getting stuck.
This does have a side effect of making their sprites slightly clip into eachother but i think it's minor enough to make it worth fixing the much bigger issue of them getting stuck.
So a spacing value of 209100 seemed like a good sweet spot that lead to the least sprite clipping whilst also preventing them from getting stuck.
I let them run for 20 ingame years with the spacing value of 209100 and they never got stuck, tests with the vanilla spacing value usually had them get stuck within the first 3 years so this seems to have fixed it.
This will also only affect newly spawned versions of these vehicles, any already existing ones will use the old spacing value until the vehicles are respawned.
Here's some screenshots to showcase the new spacing value compared to the old one.
Old:
![DeepinScreenshot_select-area_20220412032335](https://user-images.githubusercontent.com/42477864/162907386-6cc95cb8-dbd4-4ad4-a725-df1367e52b6e.png)
![DeepinScreenshot_select-area_20220412032322](https://user-images.githubusercontent.com/42477864/162907391-f64c79a2-7b48-4d17-b9d4-32efdaf179c4.png)
New:



![DeepinScreenshot_select-area_20220412034258](https://user-images.githubusercontent.com/42477864/162907617-9e39b317-c4d7-4e31-b949-f2d7889e1314.png)
![DeepinScreenshot_select-area_20220412032220](https://user-images.githubusercontent.com/42477864/162907657-9dff468a-4e5c-4bac-9b1c-626f91e6c6aa.png)

