### PR TITLE
Fix prison fence clearance height

### DIFF
--- a/objects/rct2tt/scenery_wall/rct2tt.scenery_wall.jailxx19.json
+++ b/objects/rct2tt/scenery_wall/rct2tt.scenery_wall.jailxx19.json
@@ -7,7 +7,7 @@
     "objectType": "scenery_wall",
     "properties": {
         "isAllowedOnSlope": true,
-        "height": 16,
+        "height": 10,
         "price": 70,
         "sceneryGroup": "rct2.scenery_group.scgwalls"
     },


### PR DESCRIPTION
Changes the clearance height of the TT prison fence from 16 to 10 as the original value does not match the sprite at all.
Here's a screenshot to demonstrate the change.
Left = Old value
Right = New value
![DeepinScreenshot_select-area_20220417164014](https://user-images.githubusercontent.com/42477864/163731400-ce3a463d-8d64-47a1-b80c-c7b6f19cf100.png)
This change will only affect newly placed prison fences, ones already in scenarios/saves will still have the old improper value unless they are removed and replaced.
