### PR TITLE
Remove non-functional hasPrimaryColour flags from WW/TT scenery

### DIFF
--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.smoksk01.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.smoksk01.json
@@ -17,7 +17,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "isRotatable": true,
         "isAnimated": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "SMALL_SCENERY_FLAG_VISIBLE_WHEN_ZOOMED": true,
         "frameOffsets": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1brang.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1brang.json
@@ -12,7 +12,6 @@
         "height": 112,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/1X1BRANG.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1didge.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1didge.json
@@ -12,7 +12,6 @@
         "height": 168,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/1X1DIDGE.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1emuxx.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1emuxx.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/1X1EMUXX.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1kanga.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1kanga.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/1X1KANGA.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1termm.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.1x1termm.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/1X1TERMM.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.adpanda.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.adpanda.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/ADPANDA.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.antilopf.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.antilopf.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/ANTILOPF.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.antilopm.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.antilopm.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/ANTILOPM.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.antilopp.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.antilopp.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/ANTILOPP.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.babpanda.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.babpanda.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/BABPANDA.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.balllan2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.balllan2.json
@@ -12,7 +12,6 @@
         "height": 26,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/BALLLAN2.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.balllant.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.balllant.json
@@ -12,7 +12,6 @@
         "height": 80,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/BALLLANT.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.bamboopl.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.bamboopl.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.bstatue1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.bstatue1.json
@@ -12,7 +12,6 @@
         "height": 88,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/BSTATUE1.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.fstatue1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.fstatue1.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/FSTATUE1.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.icebarl1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.icebarl1.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB1H03.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.icebarl2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.icebarl2.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB1H04.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.icebarl3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.icebarl3.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB1H05.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.oriegong.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.oriegong.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/ORIEGONG.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.pcg.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.pcg.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/PCG.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.pco.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.pco.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/PCO.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.pipebase.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.pipebase.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB2H02.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.pipevent.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.pipevent.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB2H01.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.postbox.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.postbox.json
@@ -12,7 +12,6 @@
         "height": 52,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/POSTBOX.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.pst.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.pst.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/PST.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.ptj.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.ptj.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/PTJ.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.ptk.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.ptk.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/PTK.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.pva.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.pva.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/PVA.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick01.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick02.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick03.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick04.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick05.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick07.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rbrick08.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr01.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr02.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr03.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr04.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr05.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr07.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr08.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr09.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr10.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rcorr11.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab05.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab06.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab07.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab08.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab09.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab10.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab11.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab12.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab12.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab13.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab13.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab14.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab14.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg07.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg09.json
@@ -12,7 +12,6 @@
         "height": 16,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg10.json
@@ -12,7 +12,6 @@
         "height": 16,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg11.json
@@ -12,7 +12,6 @@
         "height": 16,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg12.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rgeorg12.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml01.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml02.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml06.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml07.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog01.json
@@ -12,7 +12,6 @@
         "height": 30,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog02.json
@@ -12,7 +12,6 @@
         "height": 30,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog03.json
@@ -12,7 +12,6 @@
         "height": 30,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog04.json
@@ -12,7 +12,6 @@
         "height": 30,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rlog05.json
@@ -12,7 +12,6 @@
         "height": 30,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble1.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble2.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble3.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble4.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmarble4.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud01.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud02.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud03.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rmud05.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice1.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice2.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice3.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice4.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice4.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice5.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice5.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice6.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofice6.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig01.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig02.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig03.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.roofig06.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rshogi1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rshogi1.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rshogi2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rshogi2.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rtudor01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rtudor01.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rtudor02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rtudor02.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rtudor03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rtudor03.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rwdaub01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rwdaub01.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rwdaub02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rwdaub02.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rwdaub03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rwdaub03.json
@@ -12,7 +12,6 @@
         "height": 8,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb1hspb1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb1hspb1.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SB1HSPB1.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb1hspb2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb1hspb2.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SB1HSPB2.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb1hspb3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb1hspb3.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SB1HSPB3.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb2palm1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb2palm1.json
@@ -12,7 +12,6 @@
         "height": 60,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SB2PALM1.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb2sky01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sb2sky01.json
@@ -12,7 +12,6 @@
         "height": 60,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SB2SKY01.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh1tepe.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh1tepe.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SBH1TEPE.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh1wgwh.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh1wgwh.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SBH1WGWH.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh2shlt.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh2shlt.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SBH2SHLT.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh3cskl.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh3cskl.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SBH3CSKL.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh3rt66.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh3rt66.json
@@ -12,7 +12,6 @@
         "height": 112,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SBH3RT66.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh4totm.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbh4totm.json
@@ -12,7 +12,6 @@
         "height": 184,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/SBH4TOTM.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys01.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys02.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys03.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys04.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys05.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys06.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys07.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys08.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys09.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys10.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys11.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys12.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys12.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys13.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys13.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys14.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys14.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys15.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys15.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys16.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys16.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys17.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys17.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys18.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbskys18.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind01.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind02.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind03.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind04.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind05.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind06.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind07.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind08.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind09.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind10.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind11.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind12.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind12.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind13.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind13.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind14.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind14.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind15.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind15.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind16.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind16.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind17.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind17.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind18.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind18.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind19.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind19.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind20.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind20.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind21.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwind21.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm01.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm02.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm03.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm04.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm05.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm06.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm07.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.sbwplm08.json
@@ -14,7 +14,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.smallgeo.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.smallgeo.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB1H01.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.talllan1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.talllan1.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TALLLAN1.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.talllan2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.talllan2.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TALLLAN2.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.terrarmy.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.terrarmy.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TERRARMY.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tjblock1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tjblock1.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tjblock2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tjblock2.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tjblock3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tjblock3.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt1.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": [

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt2.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": [

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt3.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": [

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt4.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.tnt4.json
@@ -12,7 +12,6 @@
         "height": 40,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": [

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt1.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt1.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT1.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt2.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt2.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT2.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt3.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt3.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT3.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt4.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt4.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT4.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt5.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt5.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT5.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt6.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt6.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT6.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt7.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt7.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT7.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt8.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt8.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT8.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt9.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.trckprt9.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/TRCKPRT9.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.ukphone.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.ukphone.json
@@ -12,7 +12,6 @@
         "height": 96,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/UKPHONE.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.vertpipe.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.vertpipe.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true
     },
     "images": ["$RCT2:OBJDATA/RSSB1H02.DAT[0..3]"],

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab09.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab10.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab11.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab12.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab12.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab13.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wdrab13.json
@@ -12,7 +12,6 @@
         "height": 48,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml01.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml02.json
@@ -12,7 +12,6 @@
         "height": 64,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml03.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml04.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml05.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml06.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor13.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor13.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor14.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor14.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor15.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor15.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor16.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor16.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor17.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor17.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor18.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wtudor18.json
@@ -12,7 +12,6 @@
         "height": 32,
         "shape": "4/4",
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "hasNoSupports": true
     },

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wbrick12.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wbrick12.json
@@ -6,7 +6,6 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
-        "hasPrimaryColour": true,
         "isAllowedOnSlope": true,
         "height": 2,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wbrick13.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wbrick13.json
@@ -6,7 +6,6 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
-        "hasPrimaryColour": true,
         "isAllowedOnSlope": true,
         "height": 1,
         "price": 50


### PR DESCRIPTION
Removes the non-functional hasPrimaryColour flags from a ton of WW small scenery/wall pieces plus one random TT small scenery that also somehow got it.
One thing to note is that the baby elephant and red brick wall piece 11 technically have some recolorable pixels on them that will look bad if recoloring is disabled so i have kept their primary color flags for now, i'll save fixing them for a future PR as the recolorable pixels are definitely not intended and will need their sprites replaced to remove the bad recolorable pixels.

Here is the full list of affected scenery, i have condenced a lot of them to prevent this list from growing massive as over half of the small scenery objects in WW are affected by this bug

Africa Theming:
Curved Mud Wall Piece (All)
Corrugated Roof Piece (All)
Watte & Daub Roof (All)
Antelope Male
Antelope Female
Antelope Pair
TNT Stack
TNT Barrels
TNT Detonator
TNT Crates
Diamond Cart
Empty Cart
Diamond Shaft
Cart Shaft
Track Bend
Track Broke
Track End
Track Split
Track Straight

Antarctic Theming:
Igloo Wall (All)
Ice Roof (All)
Small Geosphere
Ice Pipe Section
Ice Barrels (All)
Ice Pipe Vent
Ice Pipe Base
Pipe (All)

Asia Theming:
Adult Panda
Baby Panda
Ball Lantern (All)
Asian Gong
Bamboo Plinth
Tall Lantern (All)
Terracotta Army
Maharaja Palace Piece (All)
Marble Roof (All)
Japanese Roof (All)

Australasian Theming:
Digeridoo
Boomerang
Kangaroo
Termite Mound
Emu

Europe Theming:
British Telephone Box
British Post Box
Broken Statue
Fixed Statue
Red Brick Roof Piece (All)
Red Brick Wall Piece 12
Red Brick Wall Piece 13
Kremlin Minaret Piece 1 (This object is not even named properly so don't mistake it for the dome pieces, thanks frontier)
Kremlin Minaret Piece 2 (Same as above)
Kremlin Small Tower Mid-Section
Kremlin Small Tower Base
Kremlin Step-up Wall Piece (All)
Kremlin Wall Piece (All)
Drab Small Tower Minaret Base
Drab Small Tower Top or Mid-Section
Drab Small Tower Base
Drab Minaret Piece (All)
Drab Roof Piece (All)
Drab Step-up Piece (All)
Drab Wall Piece (All)
Georgian Roof Piece 5
Georgian Flat Roof Edge (All)
Georgian Flat Roof Corner
Georgian Roof Piece 7
Tudor Roof Piece (All)
Tudor Ground Bay Wall Piece
Tudor Ground Floor Wall Piece (All)

North America Theming:
Log Cabin Roof Piece (All)
Log Cabin Wall Piece (All)
Stone Skyscraper Stairway Base
Stone Skyscraper Wall Piece (All)
Skyscraper Lift Piece (All)
Skyscraper Convex Piece (All)
Skyscraper Concave Piece (All)
Sky Scraper Roof Piece (All)
Wind Sculpted (All)
Cabana Porch (All)
Cabana Top
Cabana Roof Piece (All)
Cabana Wall Piece (All)
Cattle Skull
Route 66 Sign
Large Totem Pole
Search Light
Tee Pee
Wagon Wheel
Suspension Bridge Base Piece
Suspension Bridge Base Spacer Piece
Suspension Bridge Mid Section Piece

Roaring Twenties Theming:
Large Smoking Chimney