### PR TITLE
Remove non-functional hasPrimaryColour flags from ROOF13 and ROOF14

### DIFF
--- a/objects/rct2/scenery_small/rct2.scenery_small.roof13.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.roof13.json
@@ -15,7 +15,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true

--- a/objects/rct2/scenery_small/rct2.scenery_small.roof14.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.roof14.json
@@ -15,7 +15,6 @@
         "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
-        "hasPrimaryColour": true,
         "isStackable": true,
         "prohibitWalls": true,
         "hasNoSupports": true


### PR DESCRIPTION
These two base game objects have the option to be recoloured but have no recolourable pixels.