### PR TITLE
Surface Source Game Fixes

### DIFF
--- a/objects/rct2/terrain_surface/rct2.terrain_surface.chequerboard.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.chequerboard.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SCH|00000000",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": ["rct2", "rct1"],
     "objectType": "terrain_surface",
     "properties": {
         "price": 100,

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.grid_green.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.grid_green.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SIG|00000000",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "terrain_surface",
     "properties": {
         "colour": "bright_green",

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.grid_purple.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.grid_purple.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SIP|00000000",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "terrain_surface",
     "properties": {
         "colour": "bright_purple",

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.grid_red.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.grid_red.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SIR|00000000",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "terrain_surface",
     "properties": {
         "colour": "bright_red",

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.grid_yellow.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.grid_yellow.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SIY|00000000",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": ["rct2", "rct1ll"],
     "objectType": "terrain_surface",
     "properties": {
         "colour": "bright_yellow",

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.martian.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.martian.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SMA|00000000",
-    "sourceGame": ["rct2", "rct1aa"],
+    "sourceGame": ["rct2", "rct1"],
     "objectType": "terrain_surface",
     "properties": {
         "price": 100,

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.sand.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.sand.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SSY|00000000",
-    "sourceGame": "rct2",
+    "sourceGame": ["rct2", "rct1"],
     "objectType": "terrain_surface",
     "properties": {
         "price": 100,

--- a/objects/rct2/terrain_surface/rct2.terrain_surface.sand_brown.json
+++ b/objects/rct2/terrain_surface/rct2.terrain_surface.sand_brown.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0000008B|#RCT2SSA|00000000",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": "rct2",
     "objectType": "terrain_surface",
     "properties": {
         "price": 110,


### PR DESCRIPTION
Fixes the rct1 source games of the rct2 terrain surfaces as many of them were incorrect.

Normal sand, martian rocks, and checkerboard are now rct1
Red/Purple/Yellow/Green grids are now rct1ll
Brown sand is no longer rct1

This fixes #183