### PR TITLE
Allow 8 cars per train on flying coaster trains

### DIFF
--- a/objects/rct2/ride/rct2.ride.bmair.json
+++ b/objects/rct2/ride/rct2.ride.bmair.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 7,
+        "maxCarsPerTrain": 8,
         "carColours": [
             [
                 ["bright_red", "yellow", "dark_purple"]

--- a/objects/rct2tt/ride/rct2tt.ride.pterodac.json
+++ b/objects/rct2tt/ride/rct2tt.ride.pterodac.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 7,
+        "maxCarsPerTrain": 8,
         "carColours": [
             [
                 ["bright_red", "yellow", "dark_purple"]

--- a/objects/rct2ww/ride/rct2ww.ride.condorrd.json
+++ b/objects/rct2ww/ride/rct2ww.ride.condorrd.json
@@ -10,7 +10,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 7,
+        "maxCarsPerTrain": 8,
         "carColours": [
             [
                 ["bright_red", "yellow", "dark_purple"]


### PR DESCRIPTION
There are some irl b&m flying coaster trains that run 8 cars per train such as the two super man ultimate flight clones at six flags great america/great adventure along with a few others.
So i don't think it would be unrealistic for us to increase the max cars per train of our flying coaster object to 8 as we have increased max cars on other trains for irl parity before if i'm not mistaken.

Also increases the max cars to 8 for the expansion reskins of the trains as well.
![DeepinScreenshot_select-area_20220526233009](https://user-images.githubusercontent.com/42477864/170627166-35cf9573-8aae-41fd-9927-6841d017722d.png)

