### PR TITLE
Optimize Invisible Car Sprites

### DIFF
--- a/objects/official/ride/rct2dlc.ride.zpanda/object.json
+++ b/objects/official/ride/rct2dlc.ride.zpanda/object.json
@@ -50,14 +50,14 @@
                 "loadingPositions": [ 0 ]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -796,37 +796,6 @@
         { "path": "images/000728.png","x": -4, "y": -16 },
         { "path": "images/000729.png","x": -9, "y": -16 },
         { "path": "images/000730.png","x": -5, "y": -13 },
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
         ""
     ],
     "strings": {

--- a/objects/rct2/ride/rct2.ride.4x4.json
+++ b/objects/rct2/ride/rct2.ride.4x4.json
@@ -55,21 +55,21 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour2": true,
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/4X4.DAT[0..426]"],
+    "images": ["$RCT2:OBJDATA/4X4.DAT[0..394]", ""],
     "strings": {
         "name": {
             "en-GB": "Monster Trucks",

--- a/objects/rct2/ride/rct2.ride.cstboat.json
+++ b/objects/rct2/ride/rct2.ride.cstboat.json
@@ -54,14 +54,14 @@
                 "loadingPositions": [7, 9, 2, 4, -3, -1]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 8,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
@@ -69,7 +69,7 @@
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/CSTBOAT.DAT[0..1762]"],
+    "images": ["$RCT2:OBJDATA/CSTBOAT.DAT[0..1730]", ""],
     "strings": {
         "name": {
             "en-GB": "Coaster Boats",

--- a/objects/rct2/ride/rct2.ride.ctcar.json
+++ b/objects/rct2/ride/rct2.ride.ctcar.json
@@ -45,21 +45,21 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 70,
                 "poweredMaxSpeed": 7,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/CTCAR.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/CTCAR.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Cheshire Cats",

--- a/objects/rct2/ride/rct2.ride.gtc.json
+++ b/objects/rct2/ride/rct2.ride.gtc.json
@@ -51,14 +51,14 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 9,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPoweredRideWithUnrestrictedGravity": true,
                 "hasNoUpstopWheels": true,
@@ -69,7 +69,7 @@
         ],
         "buildMenuPriority": 2
     },
-    "images": ["$RCT2:OBJDATA/GTC.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/GTC.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Ghost Train Cars",

--- a/objects/rct2/ride/rct2.ride.helicar.json
+++ b/objects/rct2/ride/rct2.ride.helicar.json
@@ -54,21 +54,21 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 40,
                 "poweredMaxSpeed": 5,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/HELICAR.DAT[0..866]"],
+    "images": ["$RCT2:OBJDATA/HELICAR.DAT[0..834]", ""],
     "strings": {
         "name": {
             "en-GB": "Mini Helicopters",

--- a/objects/rct2/ride/rct2.ride.hmcar.json
+++ b/objects/rct2/ride/rct2.ride.hmcar.json
@@ -50,14 +50,14 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 9,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPoweredRideWithUnrestrictedGravity": true,
                 "hasNoUpstopWheels": true,
@@ -68,7 +68,7 @@
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/HMCAR.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/HMCAR.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Haunted Mansion Cars",

--- a/objects/rct2/ride/rct2.ride.rcr.json
+++ b/objects/rct2/ride/rct2.ride.rcr.json
@@ -48,21 +48,21 @@
                 "loadingPositions": [0]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 110,
                 "poweredMaxSpeed": 9,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ],
         "buildMenuPriority": 4
     },
-    "images": ["$RCT2:OBJDATA/RCR.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/RCR.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Racing Cars",

--- a/objects/rct2/ride/rct2.ride.smc1.json
+++ b/objects/rct2/ride/rct2.ride.smc1.json
@@ -71,21 +71,21 @@
                 "loadingPositions": [7, 9, -3, -1]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
         ],
         "buildMenuPriority": 3
     },
-    "images": ["$RCT2:OBJDATA/SMC1.DAT[0..622]"],
+    "images": ["$RCT2:OBJDATA/SMC1.DAT[0..590]", ""],
     "strings": {
         "name": {
             "en-GB": "Mouse Cars",

--- a/objects/rct2/ride/rct2.ride.smc2.json
+++ b/objects/rct2/ride/rct2.ride.smc2.json
@@ -43,14 +43,14 @@
                 "loadingPositions": [7, 9, -3, -1]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -61,7 +61,8 @@
         "$RCT2:OBJDATA/SMC2.DAT[1]",
         "",
         "",
-        "$RCT2:OBJDATA/SMC2.DAT[3..586]"
+        "$RCT2:OBJDATA/SMC2.DAT[3..554]",
+        ""
     ],
     "strings": {
         "name": {

--- a/objects/rct2/ride/rct2.ride.spboat.json
+++ b/objects/rct2/ride/rct2.ride.spboat.json
@@ -53,7 +53,7 @@
                 "loadingPositions": [14, 12, 14, 12, 6, 4, 6, 4, -6, -4, -6, -4, -14, -12, -14, -12]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "soundRange": 0,
                 "poweredAcceleration": 255,
@@ -61,8 +61,8 @@
                 "carVisual": 8,
                 "effectVisual": 13,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "isPowered": true,
@@ -72,7 +72,7 @@
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/SPBOAT.DAT[0..1690]"],
+    "images": ["$RCT2:OBJDATA/SPBOAT.DAT[0..1658]", ""],
     "strings": {
         "name": {
             "en-GB": "Splash Boats",

--- a/objects/rct2/ride/rct2.ride.spcar.json
+++ b/objects/rct2/ride/rct2.ride.spcar.json
@@ -42,21 +42,21 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ],
         "buildMenuPriority": 5
     },
-    "images": ["$RCT2:OBJDATA/SPCAR.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/SPCAR.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Sports Cars",

--- a/objects/rct2/ride/rct2.ride.tram1.json
+++ b/objects/rct2/ride/rct2.ride.tram1.json
@@ -51,7 +51,7 @@
                 "loadingPositions": [12, -12, 12, -12, 12, -12, 13, 11, -13, -11]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 31,
                 "soundRange": 4,
@@ -59,8 +59,8 @@
                 "poweredMaxSpeed": 19,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "isPowered": true
@@ -68,7 +68,7 @@
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/TRAM1.DAT[0..802]"],
+    "images": ["$RCT2:OBJDATA/TRAM1.DAT[0..770]", ""],
     "strings": {
         "name": {
             "en-GB": "Trams",

--- a/objects/rct2/ride/rct2.ride.truck1.json
+++ b/objects/rct2/ride/rct2.ride.truck1.json
@@ -47,14 +47,14 @@
                 "loadingPositions": [4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -65,7 +65,8 @@
         "$RCT2:OBJDATA/TRUCK1.DAT[1]",
         "",
         "",
-        "$RCT2:OBJDATA/TRUCK1.DAT[3..266]"
+        "$RCT2:OBJDATA/TRUCK1.DAT[3..234]",
+        ""
     ],
     "strings": {
         "name": {

--- a/objects/rct2/ride/rct2.ride.vcr.json
+++ b/objects/rct2/ride/rct2.ride.vcr.json
@@ -45,21 +45,21 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 60,
                 "poweredMaxSpeed": 7,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ],
         "buildMenuPriority": 2
     },
-    "images": ["$RCT2:OBJDATA/VCR.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/VCR.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Vintage Cars",

--- a/objects/rct2/ride/rct2.ride.wmmine.json
+++ b/objects/rct2/ride/rct2.ride.wmmine.json
@@ -50,21 +50,21 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 1,
                 "soundRange": 0,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/WMMINE.DAT[0..1138]"],
+    "images": ["$RCT2:OBJDATA/WMMINE.DAT[0..1106]", ""],
     "strings": {
         "name": {
             "en-GB": "Mine Cars",

--- a/objects/rct2/ride/rct2.ride.wmouse.json
+++ b/objects/rct2/ride/rct2.ride.wmouse.json
@@ -51,21 +51,21 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 1,
                 "soundRange": 0,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
         ],
         "buildMenuPriority": 2
     },
-    "images": ["$RCT2:OBJDATA/WMOUSE.DAT[0..1138]"],
+    "images": ["$RCT2:OBJDATA/WMOUSE.DAT[0..1106]", ""],
     "strings": {
         "name": {
             "en-GB": "Mouse Cars",

--- a/objects/rct2/ride/rct2.ride.zldb.json
+++ b/objects/rct2/ride/rct2.ride.zldb.json
@@ -76,21 +76,21 @@
                 "loadingPositions": [2, 4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
         ],
         "buildMenuPriority": 3
     },
-    "images": ["$RCT2:OBJDATA/ZLDB.DAT[0..1490]"],
+    "images": ["$RCT2:OBJDATA/ZLDB.DAT[0..1458]", ""],
     "strings": {
         "name": {
             "en-GB": "Ladybird Trains",

--- a/objects/rct2/ride/rct2.ride.zlog.json
+++ b/objects/rct2/ride/rct2.ride.zlog.json
@@ -73,14 +73,14 @@
                 "loadingPositions": [2, 4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -91,7 +91,8 @@
         "$RCT2:OBJDATA/ZLOG.DAT[1]",
         "",
         "",
-        "$RCT2:OBJDATA/ZLOG.DAT[3..1490]"
+        "$RCT2:OBJDATA/ZLOG.DAT[3..1458]",
+        ""
     ],
     "strings": {
         "name": {

--- a/objects/rct2tt/ride/rct2tt.ride.flygboat.json
+++ b/objects/rct2tt/ride/rct2tt.ride.flygboat.json
@@ -55,21 +55,21 @@
                 "loadingPositions": [7, 9, 2, 4, -3, -1]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 8,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/FLYGBOAT.DAT[0..1762]"],
+    "images": ["$RCT2:OBJDATA/FLYGBOAT.DAT[0..1730]", ""],
     "strings": {
         "name": {
             "en-GB": "Flying Boats",

--- a/objects/rct2tt/ride/rct2tt.ride.hovercar.json
+++ b/objects/rct2tt/ride/rct2tt.ride.hovercar.json
@@ -47,14 +47,14 @@
                 "loadingPositions": [4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -64,7 +64,8 @@
         "$RCT2:OBJDATA/HOVERCAR.DAT[1]",
         "",
         "",
-        "$RCT2:OBJDATA/HOVERCAR.DAT[3..266]"
+        "$RCT2:OBJDATA/HOVERCAR.DAT[3..234]",
+        ""
     ],
     "strings": {
         "name": {

--- a/objects/rct2tt/ride/rct2tt.ride.pegasusx.json
+++ b/objects/rct2tt/ride/rct2tt.ride.pegasusx.json
@@ -47,21 +47,21 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 60,
                 "poweredMaxSpeed": 7,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/PEGASUSX.DAT[0..866]"],
+    "images": ["$RCT2:OBJDATA/PEGASUSX.DAT[0..834]", ""],
     "strings": {
         "name": {
             "en-GB": "Pegasus Cars",

--- a/objects/rct2tt/ride/rct2tt.ride.schoolbs.json
+++ b/objects/rct2tt/ride/rct2tt.ride.schoolbs.json
@@ -48,6 +48,7 @@
                 "loadingPositions": [12, -12, 12, -12, 12, -12, 13, 11, -13, -11]
             },
             {
+                "rotationFrameMask": 0,
                 "spacing": 139456,
                 "frictionSoundId": 31,
                 "soundRange": 4,
@@ -55,14 +56,14 @@
                 "poweredMaxSpeed": 19,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/SCHOOLBS.DAT[0..802]"],
+    "images": ["$RCT2:OBJDATA/SCHOOLBS.DAT[0..770]", ""],
     "strings": {
         "name": {
             "en-GB": "School Bus Trams",

--- a/objects/rct2tt/ride/rct2tt.ride.trilobte.json
+++ b/objects/rct2tt/ride/rct2tt.ride.trilobte.json
@@ -53,20 +53,20 @@
                 "loadingPositions": [7, 9, 2, 4, -3, -1]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 8,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/TRILOBTE.DAT[0..1762]"],
+    "images": ["$RCT2:OBJDATA/TRILOBTE.DAT[0..1730]", ""],
     "strings": {
         "name": {
             "en-GB": "Trilobite Boats",

--- a/objects/rct2ww/ride/rct2ww.ride.blackcab.json
+++ b/objects/rct2ww/ride/rct2ww.ride.blackcab.json
@@ -42,20 +42,20 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/BLACKCAB.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/BLACKCAB.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Black Cabs",

--- a/objects/rct2ww/ride/rct2ww.ride.crnvbfly.json
+++ b/objects/rct2ww/ride/rct2ww.ride.crnvbfly.json
@@ -43,20 +43,20 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/CRNVBFLY.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/CRNVBFLY.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Carnival Butterfly Cars",

--- a/objects/rct2ww/ride/rct2ww.ride.crnvfrog.json
+++ b/objects/rct2ww/ride/rct2ww.ride.crnvfrog.json
@@ -43,20 +43,20 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/CRNVFROG.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/CRNVFROG.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Carnival Frog Cars",

--- a/objects/rct2ww/ride/rct2ww.ride.crnvlzrd.json
+++ b/objects/rct2ww/ride/rct2ww.ride.crnvlzrd.json
@@ -43,20 +43,20 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/CRNVLZRD.DAT[0..242]"],
+    "images": ["$RCT2:OBJDATA/CRNVLZRD.DAT[0..210]", ""],
     "strings": {
         "name": {
             "en-GB": "Carnival Lizard Cars",

--- a/objects/rct2ww/ride/rct2ww.ride.huskie.json
+++ b/objects/rct2ww/ride/rct2ww.ride.huskie.json
@@ -46,20 +46,20 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 60,
                 "poweredMaxSpeed": 7,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/HUSKIE.DAT[0..866]"],
+    "images": ["$RCT2:OBJDATA/HUSKIE.DAT[0..834]", ""],
     "strings": {
         "name": {
             "en-GB": "Huskie Car",

--- a/objects/rct2ww/ride/rct2ww.ride.londonbs.json
+++ b/objects/rct2ww/ride/rct2ww.ride.londonbs.json
@@ -48,6 +48,7 @@
                 "loadingPositions": [12, -12, 12, -12, 12, -12, 13, 11, -13, -11]
             },
             {
+                "rotationFrameMask": 0,
                 "spacing": 139456,
                 "frictionSoundId": 31,
                 "soundRange": 4,
@@ -55,14 +56,14 @@
                 "poweredMaxSpeed": 19,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/LONDONBS.DAT[0..802]"],
+    "images": ["$RCT2:OBJDATA/LONDONBS.DAT[0..770]", ""],
     "strings": {
         "name": {
             "en-GB": "Routemaster Buses",

--- a/objects/rct2ww/ride/rct2ww.ride.mantaray.json
+++ b/objects/rct2ww/ride/rct2ww.ride.mantaray.json
@@ -54,21 +54,21 @@
                 "loadingPositions": [7, 9, 2, 4, -3, -1]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 8,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/MANTARAY.DAT[0..1762]"],
+    "images": ["$RCT2:OBJDATA/MANTARAY.DAT[0..1730]", ""],
     "strings": {
         "name": {
             "en-GB": "Manta Ray Boats",

--- a/objects/rct2ww/ride/rct2ww.ride.sanftram.json
+++ b/objects/rct2ww/ride/rct2ww.ride.sanftram.json
@@ -51,7 +51,7 @@
                 "loadingPositions": [12, -12, 12, -12, 12, -12, 13, 11, -13, -11]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 31,
                 "soundRange": 4,
@@ -59,15 +59,15 @@
                 "poweredMaxSpeed": 19,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour1": true,
                 "isPowered": true
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/SANFTRAM.DAT[0..802]"],
+    "images": ["$RCT2:OBJDATA/SANFTRAM.DAT[0..770]", ""],
     "strings": {
         "name": {
             "en-GB": "San Francisco Trams",

--- a/objects/rct2ww/ride/rct2ww.ride.surfbrdc.json
+++ b/objects/rct2ww/ride/rct2ww.ride.surfbrdc.json
@@ -63,26 +63,15 @@
                 "loadingPositions": [-2, -4, -2, -4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 69728,
                 "mass": 525,
                 "frictionSoundId": 57,
                 "soundRange": 0,
+                "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true,
-                    "gentleSlopes": true,
-                    "steepSlopes": true,
-                    "verticalSlopes": true,
-                    "diagonalSlopes": true,
-                    "flatBanked": true,
-                    "inlineTwists": true,
-                    "flatToGentleSlopeBankedTransitions": true,
-                    "diagonalGentleSlopeBankedTransitions": true,
-                    "gentleSlopeBankedTransitions": true,
-                    "gentleSlopeBankedTurns": true,
-                    "flatToGentleSlopeWhileBankedTransitions": true,
-                    "corkscrews": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
@@ -90,7 +79,7 @@
             }
         ]
     },
-    "images": ["$RCT2:OBJDATA/SURFBRDC.DAT[0..3350]"],
+    "images": ["$RCT2:OBJDATA/SURFBRDC.DAT[0..2522]", ""],
     "strings": {
         "name": {
             "en-GB": "Surfing Trains",

--- a/objects/rct2ww/ride/rct2ww.ride.whicgrub.json
+++ b/objects/rct2ww/ride/rct2ww.ride.whicgrub.json
@@ -73,14 +73,14 @@
                 "loadingPositions": [2, 4]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
-                "frames": {
-                    "flat": true
+                "spriteGroups": {
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -90,7 +90,8 @@
         "$RCT2:OBJDATA/WHICGRUB.DAT[1]",
         "",
         "",
-        "$RCT2:OBJDATA/WHICGRUB.DAT[3..1490]"
+        "$RCT2:OBJDATA/WHICGRUB.DAT[3..1458]",
+        ""
     ],
     "strings": {
         "name": {


### PR DESCRIPTION
With the frames rotation refactor getting merged recently we can now remove many of the duplicate invisible sprites that certain vehicles use for their invisible cars.
This works by making all of the invisible cars of rides only use 1 frame of slopeFlat rather than the full 32 which reduces the amount of sprites by 31 for most vehicles.
There is one exception to this, as the WW surfing board coaster trains uses *many* sprite groups for it's invisible car, this causes it to waste over 800 sprites for it's invisible car!
I have changed this so it's more like other the invisible cars in this PR to make it only use a mere 1 frame of slopeFlat and also went ahead and made it use "carVisual": 1 like the other invisible cars.

This PR saves a total of 1850 sprites from all of the rides with invisible cars

I also added a missing "rotationFrameMask" to the WW routemaster bus trams & TT school bus trams as they weren't there for some reason.
I've also went ahead and made the invisible sprites all use the same generic "" invisible sprite entry which should make these objects more opengraphics friendly as this means opengraphics won't have to provide tons of duplicate invisible sprites for these vehicles in the future.