### PR TITLE
German: path surface/railing, audio, coaster

### DIFF
--- a/objects/official/footpath_railings/openrct2.footpath_railings.invisible.json
+++ b/objects/official/footpath_railings/openrct2.footpath_railings.invisible.json
@@ -16,6 +16,7 @@
   "strings": {
     "name": {
       "en-GB": "Invisible Railings",
+      "de-DE": "Unsichtbare Geländer",
       "nl-NL": "Onzichtbare ondersteuningen"
     }
   }

--- a/objects/official/footpath_surface/openrct2.footpath_surface.invisible.json
+++ b/objects/official/footpath_surface/openrct2.footpath_surface.invisible.json
@@ -13,6 +13,7 @@
   "strings": {
     "name": {
       "en-GB": "Invisible Footpath",
+      "de-DE": "Unsichtbarer Fußweg",
       "nl-NL": "Onzichtbaar pad"
     }
   }

--- a/objects/official/footpath_surface/openrct2.footpath_surface.queue_invisible.json
+++ b/objects/official/footpath_surface/openrct2.footpath_surface.queue_invisible.json
@@ -13,6 +13,7 @@
   "strings": {
     "name": {
       "en-GB": "Invisible Queue",
+      "de-DE": "Unsichtbare Warteschlange",
       "nl-NL": "Onzichtbare wachtrij"
     }
   }

--- a/objects/official/ride/openrct2.ride.hybrid_coaster/object.json
+++ b/objects/official/ride/openrct2.ride.hybrid_coaster/object.json
@@ -154,14 +154,17 @@
     "strings": {
         "name": {
             "en-GB": "Hybrid Coaster Trains",
+            "de-DE": "Hybridachterbahnzüge",
             "nl-NL": "Trein voor hybride achtbaan"
         },
         "description": {
             "en-GB": "Roller coaster trains with lap restraints, capable of steep drops and inversions",
+            "de-DE": "Achterbahnzüge mit Schoßhalterungen; für steile Stürze und Inversionen geeignet",
             "nl-NL": "Achtbaantreinen met schootbeugels, die geschikt zijn voor steile heilingen en omkeringen."
         },
         "capacity": {
             "en-GB": "4 passengers per car",
+            "de-DE": "4 Fahrgäste pro Wagen",
             "nl-NL": "4 passagiers per karretje"
         }
     },

--- a/objects/official/ride/openrct2.ride.single_rail_coaster/object.json
+++ b/objects/official/ride/openrct2.ride.single_rail_coaster/object.json
@@ -148,14 +148,17 @@
     "strings": {
         "name": {
             "en-GB": "Single Rail Roller Coaster Trains",
+            "de-DE": "Einschienenachterbahnzüge",
             "nl-NL": "Trein voor achtbaan met enkele rail"
         },
         "description": {
             "en-GB": "Roller coaster trains in which riders are seated single file",
+            "de-DE": "Achterbahnzüge, in denen die Fahrgäste in einer Einzelreihe sitzen",
             "nl-NL": "Achtbaantrein waarin de passagiers achter elkaar zitten, in eigen karretjes."
         },
         "capacity": {
             "en-GB": "1 passenger per car",
+            "de-DE": "1 Fahrgast pro Wagen",
             "nl-NL": "1 passagier per karretje"
         }
     },

--- a/objects/rct1/audio/rct1.audio.title.json
+++ b/objects/rct1/audio/rct1.audio.title.json
@@ -15,7 +15,8 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Title screen music for RollerCoaster Tycoon (Loopy Landscapes)."
+            "en-GB": "Title screen music for RollerCoaster Tycoon (Loopy Landscapes).",
+            "de-DE": "Titelbildschirmmusik für RollerCoaster Tycoon (Loopy Landscapes)."
         }
     }
 }

--- a/objects/rct1/footpath_railings/rct1ll.footpath_railings.bamboo/object.json
+++ b/objects/rct1/footpath_railings/rct1ll.footpath_railings.bamboo/object.json
@@ -27,6 +27,7 @@
     "strings": {
         "name": {
             "en-GB": "Bamboo Railings (Yellow)",
+            "de-DE": "Bambusgeländer (gelb)",
             "nl-NL": "Ondersteuningen van bamboe (geel)"
         }
     }

--- a/objects/rct1/footpath_railings/rct1ll.footpath_railings.space/object.json
+++ b/objects/rct1/footpath_railings/rct1ll.footpath_railings.space/object.json
@@ -20,6 +20,7 @@
         "name": {
             "en-GB": "Space Style Railings (Grey)",
             "en-US": "Space Style Railings (Gray)",
+            "de-DE": "Weltraumstilgeländer (grau)",
             "nl-NL": "Ruimte-ondersteuningen (grijs)"
         }
     }

--- a/objects/rct1/footpath_surface/rct1.footpath_surface.crazy_paving/object.json
+++ b/objects/rct1/footpath_surface/rct1.footpath_surface.crazy_paving/object.json
@@ -19,7 +19,7 @@
         "name": {
             "en-GB": "Crazy Paving Footpath (Sloped)",
             "fr-FR": "Allée pavée",
-            "de-DE": "Fußweg mit verrücktem Belag",
+            "de-DE": "Fußweg mit verrücktem Belag (Schräge)",
             "es-ES": "Sendero de empedrado loco",
             "it-IT": "Sentiero strampalato",
             "nl-NL": "Voetpad met onregelmatig plaveisel",

--- a/objects/rct1/footpath_surface/rct1.footpath_surface.dirt/object.json
+++ b/objects/rct1/footpath_surface/rct1.footpath_surface.dirt/object.json
@@ -19,7 +19,7 @@
         "name": {
             "en-GB": "Dirt Footpath (Square)",
             "fr-FR": "Allée en terre",
-            "de-DE": "Dreckfußweg",
+            "de-DE": "Dreckfußweg (quadratisch)",
             "es-ES": "Sendero sucio",
             "it-IT": "Sentiero di terra",
             "nl-NL": "Onverhard voetpad",

--- a/objects/rct1/footpath_surface/rct1.footpath_surface.queue_blue/object.json
+++ b/objects/rct1/footpath_surface/rct1.footpath_surface.queue_blue/object.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Blue Queue (Sloped)",
+            "de-DE": "Blaue Warteschlange (Schräge)",
             "nl-NL": "Wachtrij (blauw)"
         }
     }

--- a/objects/rct1/footpath_surface/rct1.footpath_surface.tarmac/object.json
+++ b/objects/rct1/footpath_surface/rct1.footpath_surface.tarmac/object.json
@@ -17,7 +17,7 @@
         "name": {
             "en-GB": "Tarmac Footpath (Sloped)",
             "fr-FR": "Allée en bitume",
-            "de-DE": "Makadam-Fußweg",
+            "de-DE": "Makadam-Fußweg (Schräge)",
             "es-ES": "Sendero asfaltado",
             "it-IT": "Sentiero di catrame",
             "nl-NL": "Voetpad van asfalt",

--- a/objects/rct1/footpath_surface/rct1aa.footpath_surface.ash/object.json
+++ b/objects/rct1/footpath_surface/rct1aa.footpath_surface.ash/object.json
@@ -19,7 +19,7 @@
         "name": {
             "en-GB": "Ash Footpath (Square)",
             "fr-FR": "Allée en bois",
-            "de-DE": "Aschefußweg",
+            "de-DE": "Aschefußweg (quadratisch)",
             "es-ES": "Sendero de ceniza",
             "it-IT": "Sentiero di cenere",
             "nl-NL": "Voetpad met aslaag",

--- a/objects/rct1/footpath_surface/rct1aa.footpath_surface.queue_green/object.json
+++ b/objects/rct1/footpath_surface/rct1aa.footpath_surface.queue_green/object.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Green Queue",
+            "de-DE": "Grüne Warteschlange",
             "nl-NL": "Wachtrij (groen)"
         }
     }

--- a/objects/rct1/footpath_surface/rct1aa.footpath_surface.queue_red/object.json
+++ b/objects/rct1/footpath_surface/rct1aa.footpath_surface.queue_red/object.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Red Queue (Sloped)",
+            "de-DE": "Rote Warteschlange (Schräge)",
             "nl-NL": "Wachtrij (rood)"
         }
     }

--- a/objects/rct1/footpath_surface/rct1aa.footpath_surface.queue_yellow/object.json
+++ b/objects/rct1/footpath_surface/rct1aa.footpath_surface.queue_yellow/object.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Yellow Queue (Sloped)",
+            "de-DE": "Gelbe Warteschlange (Schräge)",
             "nl-NL": "Wachtrij (geel)"
         }
     }

--- a/objects/rct1/footpath_surface/rct1aa.footpath_surface.tarmac_brown/object.json
+++ b/objects/rct1/footpath_surface/rct1aa.footpath_surface.tarmac_brown/object.json
@@ -19,7 +19,7 @@
         "name": {
             "en-GB": "Brown Tarmac Footpath (Sloped)",
             "fr-FR": "Allée en bitume marron",
-            "de-DE": "Brauner Makadam-Fußweg",
+            "de-DE": "Brauner Makadam-Fußweg (Schräge)",
             "es-ES": "Sendero asfaltado marrón",
             "it-IT": "Sentiero di catrame marrone",
             "nl-NL": "Voetpad van bruin asfalt",

--- a/objects/rct1/footpath_surface/rct1aa.footpath_surface.tarmac_red/object.json
+++ b/objects/rct1/footpath_surface/rct1aa.footpath_surface.tarmac_red/object.json
@@ -18,6 +18,7 @@
     "strings": {
         "name": {
             "en-GB": "Red Tarmac Footpath (Sloped)",
+            "de-DE": "Roter Makadam-Fußweg (Schräge)",
             "fr-FR": "Allée en bitume rouge",
             "de-DE": "Roter Makadam-Fußweg",
             "nl-NL": "Voetpad van rood asfalt"

--- a/objects/rct2/audio/rct2.audio.base.json
+++ b/objects/rct2/audio/rct2.audio.base.json
@@ -87,7 +87,8 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Base audio for the game."
+            "en-GB": "Base audio for the game.",
+            "de-DE": "Basisaudio für das Spiel."
         }
     }
 }

--- a/objects/rct2/audio/rct2.audio.circus.json
+++ b/objects/rct2/audio/rct2.audio.circus.json
@@ -14,7 +14,8 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Ambient sound effects for the Circus attraction."
+            "en-GB": "Ambient sound effects for the Circus attraction.",
+            "de-DE": "Umgebungsgeräusche für die Zirkusattraktion."
         }
     }
 }

--- a/objects/rct2/audio/rct2.audio.title.json
+++ b/objects/rct2/audio/rct2.audio.title.json
@@ -14,7 +14,8 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Title screen music for RollerCoaster Tycoon 2."
+            "en-GB": "Title screen music for RollerCoaster Tycoon 2.",
+            "de-DE": "Titelbildschirmmusik für RollerCoaster Tycoon 2."
         }
     }
 }

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_black/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_black/object.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Bamboo Railings (Black)",
+            "de-DE": "Bambusgeländer (schwarz)",
             "nl-NL": "Ondersteuningen van bamboe (zwart)"
         }
     }

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_brown/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.bamboo_brown/object.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Bamboo Railings (Brown)",
+            "de-DE": "Bambusgeländer (braun)",
             "nl-NL": "Ondersteuningen van bamboe (bruin)"
         }
     }

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.concrete/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.concrete/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Concrete Railings (Grey-Brown)",
+            "de-DE": "Betongeländer (graubraun)",
             "nl-NL": "Betonnen ondersteuningen"
         }
     }

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.concrete_green/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.concrete_green/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Concrete Railings (Dark Green)",
+            "de-DE": "Betongeländer (dunkelgrün)",
             "nl-NL": "Betonnen ondersteuningen (groen)"
         }
     }

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.space/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.space/object.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Space Style Railings (Red)",
+            "de-DE": "Weltraumstilgeländer (rot)",
             "nl-NL": "Ruimte-ondersteuningen (rood)"
         }
     }

--- a/objects/rct2/footpath_railings/rct2.footpath_railings.wood/object.json
+++ b/objects/rct2/footpath_railings/rct2.footpath_railings.wood/object.json
@@ -16,6 +16,7 @@
     "strings": {
         "name": {
             "en-GB": "Wooden Railings",
+            "de-DE": "Holzgeländer",
             "nl-NL": "Houten ondersteuningen"
         }
     }

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.ash/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.ash/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Ash Footpath (Rounded)",
             "fr-FR": "Allée en bois",
-            "de-DE": "Aschefußweg",
+            "de-DE": "Aschefußweg (rund)",
             "es-ES": "Sendero de ceniza",
             "it-IT": "Sentiero di cenere",
             "nl-NL": "Voetpad met aslaag",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.crazy_paving/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.crazy_paving/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Crazy Paving Footpath (Stairs)",
             "fr-FR": "Allée pavée",
-            "de-DE": "Fußweg mit verrücktem Belag",
+            "de-DE": "Fußweg mit verrücktem Belag (Treppe)",
             "es-ES": "Sendero de empedrado loco",
             "it-IT": "Sentiero strampalato",
             "nl-NL": "Voetpad met onregelmatig plaveisel",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.dirt/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.dirt/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Dirt Footpath (Rounded)",
             "fr-FR": "Allée en terre",
-            "de-DE": "Dreckfußweg",
+            "de-DE": "Dreckfußweg (rund)",
             "es-ES": "Sendero sucio",
             "it-IT": "Sentiero di terra",
             "nl-NL": "Onverhard voetpad",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_blue/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_blue/object.json
@@ -14,6 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Blue Queue (Stairs)",
+            "de-DE": "Blaue Warteschlange (Treppe)",
             "nl-NL": "Wachtrij (blauw)"
         }
     }

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_green/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_green/object.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Dark Green Queue",
+            "de-DE": "Dunkelgrüne Warteschlange",
             "nl-NL": "Wachtrij (groen)"
         }
     }

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_red/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_red/object.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Red Queue (Stairs)",
+            "de-DE": "Rote Warteschlange (Treppe)",
             "nl-NL": "Wachtrij (rood)"
         }
     }

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_yellow/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_yellow/object.json
@@ -15,6 +15,7 @@
     "strings": {
         "name": {
             "en-GB": "Yellow Queue (Stairs)",
+            "de-DE": "Gelbe Warteschlange (Treppe)",
             "nl-NL": "Wachtrij (geel)"
         }
     }

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Tarmac Footpath (Stairs)",
             "fr-FR": "Allée en bitume",
-            "de-DE": "Makadam-Fußweg",
+            "de-DE": "Makadam-Fußweg (Treppe)",
             "es-ES": "Sendero asfaltado",
             "it-IT": "Sentiero di catrame",
             "nl-NL": "Voetpad van asfalt",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_brown/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_brown/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Brown Tarmac Footpath (Stairs)",
             "fr-FR": "Allée en bitume marron",
-            "de-DE": "Brauner Makadam-Fußweg",
+            "de-DE": "Brauner Makadam-Fußweg (Treppe)",
             "es-ES": "Sendero asfaltado marrón",
             "it-IT": "Sentiero di catrame marrone",
             "nl-NL": "Voetpad van bruin asfalt",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_green/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_green/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Dark Green Tarmac Footpath",
             "fr-FR": "Allée en bitume vert",
-            "de-DE": "Grüner Makadam-Fußweg",
+            "de-DE": "Dunkelgrüner Makadam-Fußweg",
             "es-ES": "Sendero asfaltado verde",
             "it-IT": "Sentiero di catrame verde",
             "nl-NL": "Voetpad van groen asfalt",

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_red/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.tarmac_red/object.json
@@ -12,7 +12,7 @@
         "name": {
             "en-GB": "Red Tarmac Footpath (Stairs)",
             "fr-FR": "Allée en bitume rouge",
-            "de-DE": "Roter Makadam-Fußweg",
+            "de-DE": "Roter Makadam-Fußweg (Treppe)",
             "nl-NL": "Voetpad van rood asfalt"
         }
     }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.balustrade/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.balustrade/object.json
@@ -16,7 +16,8 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Balustrade"
+            "en-GB": "Balustrade",
+            "de-DE": "Balustrade"
         }
     }
 }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.circuitboard/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.circuitboard/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Circuit Board Railings",
+            "de-DE": "Elektronische Geländer",
             "nl-NL": "Printplaatondersteuningen"
         }
     }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.circuitboard_invisible/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.circuitboard_invisible/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Sky Walk",
+            "de-DE": "Schwebeweg",
             "nl-NL": "Ondersteuningen zonder balustrade met lichtkrant in printplaatstijl"
         }
     }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.medieval/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.medieval/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Medieval Railings",
+            "de-DE": "Mittelaltergeländer",
             "nl-NL": "Middeleeuwse ondersteuningen"
         }
     }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.pavement/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.pavement/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Iron Railings",
+            "de-DE": "Eisengeländer",
             "nl-NL": "IJzeren ondersteuningen"
         }
     }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.rainbow/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.rainbow/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Rainbow Railings",
+            "de-DE": "Regenbogengeländer",
             "nl-NL": "Regenboogondersteuningen"
         }
     }

--- a/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.rocky/object.json
+++ b/objects/rct2tt/footpath_railings/rct2tt.footpath_railings.rocky/object.json
@@ -17,6 +17,7 @@
     "strings": {
         "name": {
             "en-GB": "Jungle Railings",
+            "de-DE": "Dschungelgeländer",
             "nl-NL": "Jungleondersteuningen"
         }
     }

--- a/objects/rct2tt/footpath_surface/rct2tt.footpath_surface.queue_circuitboard/object.json
+++ b/objects/rct2tt/footpath_surface/rct2tt.footpath_surface.queue_circuitboard/object.json
@@ -14,6 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Circuit Queue",
+            "de-DE": "Elektronische Warteschlange",
             "nl-NL": "Printplaat-wachtrij"
         }
     }

--- a/objects/rct2tt/footpath_surface/rct2tt.footpath_surface.queue_pavement/object.json
+++ b/objects/rct2tt/footpath_surface/rct2tt.footpath_surface.queue_pavement/object.json
@@ -15,6 +15,7 @@
         "name": {
             "en-GB": "Pavement Queue",
             "en-US": "Sidewalk Queue",
+            "de-DE": "Bürgersteigwarteschlange",
             "nl-NL": "Stoepwachtrij"
         }
     }

--- a/objects/rct2tt/footpath_surface/rct2tt.footpath_surface.queue_rainbow/object.json
+++ b/objects/rct2tt/footpath_surface/rct2tt.footpath_surface.queue_rainbow/object.json
@@ -14,6 +14,7 @@
     "strings": {
         "name": {
             "en-GB": "Rainbow Queue",
+            "de-DE": "Regenbogenwarteschlange",
             "nl-NL": "Regenboogwachtrij"
         }
     }


### PR DESCRIPTION
This adds and updates a couple of German strings. Primarily this affects strings for footpath surfaces, footpath railings, audio and the new special OpenRCT2 rollercoasters.

PS: Is there an automated way to find out which strings of a langauge are still untranslated?