### PR TITLE
Remove "tabCar" from goltr

### DIFF
--- a/objects/rct2/ride/rct2.ride.goltr.json
+++ b/objects/rct2/ride/rct2.ride.goltr.json
@@ -12,7 +12,6 @@
         "minCarsPerTrain": 4,
         "maxCarsPerTrain": 6,
         "numEmptyCars": 1,
-        "tabCar": 1,
         "tailCars": 1,
         "ratingMultipler": {
             "excitement": 10,


### PR DESCRIPTION
This object erroneously had this property set which would cause the car followed by the train view in the ride window to be the second car rather than the first car. Along with the car tab's icon getting it's colors from the second car.

Before:
![Screenshot_select-area_20220813171540](https://user-images.githubusercontent.com/42477864/184510993-96a938a8-632b-4e87-8df6-5e394bc9816b.png)
After:
![Screenshot_select-area_20220813171647](https://user-images.githubusercontent.com/42477864/184510998-01df2adc-76c5-484b-a9bc-f9d231f928d5.png)

Fixes this issue in the main repo https://github.com/OpenRCT2/OpenRCT2/issues/17394