### PR TITLE
Steel reversed name Reversed Seats > Reversed

### DIFF
--- a/objects/rct1/ride/rct1.ride.steel_rc_trains_reversed/object.json
+++ b/objects/rct1/ride/rct1.ride.steel_rc_trains_reversed/object.json
@@ -3090,7 +3090,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Roller Coaster Trains (Reversed Seats)",
+            "en-GB": "Roller Coaster Trains (Reversed)",
             "nl-NL": "Achtbaantrein (achteruit)"
         },
         "description": {


### PR DESCRIPTION
I wanted to change this string for consistency with the reversed 6 seater wooden train from the rct2 base game's name string as it is just simply "Reversed" rather than "Reversed Seats"

This'll also be used for the upcoming rct1 wooden reversed trains