### PR TITLE
Fix author name for Fairground Organ

### DIFF
--- a/objects/rct2/music/rct2.music.fairground.json
+++ b/objects/rct2/music/rct2.music.fairground.json
@@ -1,6 +1,6 @@
 {
     "id": "rct2.music.fairground",
-    "authors": ["C. John Mears", "Bressingham Voight"],
+    "authors": ["C. John Mears", "Bressingham Voigt"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC01|00000000",
     "sourceGame": ["rct2", "rct1"],

--- a/objects/rct2/music/rct2.music.fairground.json
+++ b/objects/rct2/music/rct2.music.fairground.json
@@ -1,6 +1,6 @@
 {
     "id": "rct2.music.fairground",
-    "authors": ["Chris Sawyer", "Allister Brimble"],
+    "authors": ["C. John Mears", "Bressingham Voight"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC01|00000000",
     "sourceGame": ["rct2", "rct1"],

--- a/objects/rct2/music/rct2.music.fairground.json
+++ b/objects/rct2/music/rct2.music.fairground.json
@@ -1,6 +1,6 @@
 {
     "id": "rct2.music.fairground",
-    "authors": ["C. John Mears", "Bressingham Voigt"],
+    "authors": ["C. John Mears"],
     "version": "1.0",
     "originalId": "0000008E|#MUSIC01|00000000",
     "sourceGame": ["rct2", "rct1"],


### PR DESCRIPTION
The artist for the fairground organ is not Chris Sawyer nor Allister Brimble, it is a recording by C. John Mears of the Bressingham Voigt fairground organ.