### PR TITLE
Make reversed heartline cars use sprites from utcar.dat

### DIFF
--- a/objects/rct2/ride/rct2.ride.utcarr.json
+++ b/objects/rct2/ride/rct2.ride.utcarr.json
@@ -72,7 +72,13 @@
         ],
         "buildMenuPriority": 1
     },
-    "images": ["$RCT2:OBJDATA/UTCARR.DAT[0..2594]"],
+    "images": [
+        "$RCT2:OBJDATA/UTCAR.DAT[0]",
+        "",
+        "",
+        "$RCT2:OBJDATA/UTCAR.DAT[1299..2594]",
+        "$RCT2:OBJDATA/UTCAR.DAT[3..1298]"
+    ],
     "strings": {
         "name": {
             "en-GB": "Twister Cars (starting reversed)",


### PR DESCRIPTION
This makes the reversed heartline twister cars use sprites from the non-reversed heartline cars dat, as the sprites between the two are identical (including the thumbnail) asides from the vehicles being swapped in the sprite order. This won't make much of a difference to the average user but it does mean that custom installs can omit utcarr.dat to reduce file size (1mb) which i think would be a nice little save in exchange for just a couple of extra lines of image table text in our utcarr json.