### PR TITLE
Add real life ride vehicle color preset to magic carpet

### DIFF
--- a/objects/rct2/ride/rct2.ride.mcarpet1.json
+++ b/objects/rct2/ride/rct2.ride.mcarpet1.json
@@ -17,6 +17,9 @@
             ],
             [
                 ["grey", "bright_red", "black"]
+            ],
+		    [
+                ["yellow", "light_blue", "black"]
             ]
         ],
         "cars": {

--- a/objects/rct2/ride/rct2.ride.mcarpet1.json
+++ b/objects/rct2/ride/rct2.ride.mcarpet1.json
@@ -18,7 +18,7 @@
             [
                 ["grey", "bright_red", "black"]
             ],
-		    [
+            [
                 ["yellow", "light_blue", "black"]
             ]
         ],


### PR DESCRIPTION
this will add the blue and yellow vehicle from quantum at thorpe park to the vehicle color presets for magic carpet
![imagery](https://user-images.githubusercontent.com/94884086/200711664-7fa6121c-5e11-4fbd-80b4-9225bf3c5bb2.png)

