### PR TITLE
Remove RCT1 source game from RCT2 go karts

### DIFF
--- a/objects/rct2/ride/rct2.ride.kart1.json
+++ b/objects/rct2/ride/rct2.ride.kart1.json
@@ -3,7 +3,7 @@
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "originalId": "0A188B80|KART1   |56DFF5D7",
-    "sourceGame": ["rct2", "rct1"],
+    "sourceGame": "rct2",
     "objectType": "ride",
     "properties": {
         "type": "go_karts",


### PR DESCRIPTION
Slight oversight i missed from my RCT1 go karts pr, removes the RCT1 source game from the RCT2 go karts now that the RCT1 go karts are implemented as their own object.