### PR TITLE
Fix RCT1 rocket car rating multipliers.

### DIFF
--- a/objects/rct1/ride/rct1.ride.rocket_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.rocket_cars/object.json
@@ -10,6 +10,10 @@
         "category": "rollercoaster",
         "minCarsPerTrain": 1,
         "maxCarsPerTrain": 3,
+        "ratingMultipler": {
+            "excitement": 2,
+            "intensity": -2
+        },
         "carColours": [
             [
                 ["grey", "bright_red", "black"]


### PR DESCRIPTION
Curiously these are the only vehicles in the RCT1 vanilla game (so far that i've noticed at least) that seem to have a negative rating multiplier.
RCT1
![rocketrct1](https://user-images.githubusercontent.com/42477864/211179559-065d3896-2215-43ea-ad3f-6c3992d7f3ee.png)
OpenRCT2 after this PR, note that this is with a no air time hack active to emulate RCT1 rating behavior so the excitement/nausea will be slightly higher in the real game than here.
![rocketopen](https://user-images.githubusercontent.com/42477864/211179558-f950f740-63d5-42da-9025-5999ab24cd43.png)

Initially i was also going to tweak the reverse steel coaster train ratings with this as well but after a lot of testing i'm really not sure what is up with them as all of my tests with comparing RCT1 ratings with OpenRCT2 ratings with various different ratingmultiplier configurations have been very inconsistent so i am going to just leave them as is for now until i can resolve that.