### PR TITLE
Fix reversed steel train description

### DIFF
--- a/objects/rct1/ride/rct1.ride.steel_rc_trains_reversed/object.json
+++ b/objects/rct1/ride/rct1.ride.steel_rc_trains_reversed/object.json
@@ -3095,7 +3095,7 @@
             "nl-NL": "Achtbaantrein (achteruit)"
         },
         "description": {
-            "en-GB": "Roller coaster train with a streamlined front car.",
+            "en-GB": "Roller coaster train running in reverse, so that the passengers face backwards.",
             "nl-NL": "Achtbaantrein waarvan het voorste karretje gestroomlijnd is."
         },
         "capacity": {


### PR DESCRIPTION
Fixes a slight oversight where the description was the same as the normal steel trains, now it uses the proper description from RCT1.