### PR TITLE
Fix reversed looping trains friction sound

### DIFF
--- a/objects/rct2/ride/rct2.ride.scht1.json
+++ b/objects/rct2/ride/rct2.ride.scht1.json
@@ -58,7 +58,7 @@
                 "mass": 525,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 0,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 7,
                 "frames": {

--- a/objects/rct2tt/ride/rct2tt.ride.polchase.json
+++ b/objects/rct2tt/ride/rct2tt.ride.polchase.json
@@ -57,7 +57,7 @@
                 "mass": 600,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 0,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 7,
                 "frames": {


### PR DESCRIPTION
Was brought up in the discord. Fixes the looping trains having chain lift sounds as their friction sound for their second cars. In vanilla RCT2 this issue couldn't be heard but now with the reversed trains toggle being merged it's now very obvious.