### PR TITLE
Updated sort priorities for expansion scenery groups

### DIFF
--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920s.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920s.json
@@ -58,7 +58,7 @@
             "rct2tt.scenery_large.hrbwal09",
             "rct2tt.scenery_large.hrbwal11"
         ],
-        "priority": 47
+        "priority": 48
     },
     "images": [
         "$RCT2:OBJDATA/SCG1920S.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920s.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920s.json
@@ -58,7 +58,7 @@
             "rct2tt.scenery_large.hrbwal09",
             "rct2tt.scenery_large.hrbwal11"
         ],
-        "priority": 25
+        "priority": 47
     },
     "images": [
         "$RCT2:OBJDATA/SCG1920S.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920w.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920w.json
@@ -127,7 +127,7 @@
             "rct2tt.scenery_small.jailxx20",
             "rct2tt.scenery_small.jailxx21"
         ],
-        "priority": 48
+        "priority": 49
     },
     "images": [
         "$RCT2:OBJDATA/SCG1920W.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920w.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1920w.json
@@ -127,7 +127,7 @@
             "rct2tt.scenery_small.jailxx20",
             "rct2tt.scenery_small.jailxx21"
         ],
-        "priority": 25
+        "priority": 48
     },
     "images": [
         "$RCT2:OBJDATA/SCG1920W.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1960s.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1960s.json
@@ -49,7 +49,7 @@
             "rct2tt.scenery_small.biggutar",
             "rct2tt.scenery_large.bigdrums"
         ],
-        "priority": 25
+        "priority": 49
     },
     "images": [
         "$RCT2:OBJDATA/SCG1960S.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1960s.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scg1960s.json
@@ -49,7 +49,7 @@
             "rct2tt.scenery_small.biggutar",
             "rct2tt.scenery_large.bigdrums"
         ],
-        "priority": 49
+        "priority": 50
     },
     "images": [
         "$RCT2:OBJDATA/SCG1960S.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgfutur.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgfutur.json
@@ -119,7 +119,7 @@
             "rct2tt.scenery_small.fltsign1",
             "rct2tt.scenery_small.fltsign2"
         ],
-        "priority": 25,
+        "priority": 50,
         "entertainerCostumes": "astronaut"
     },
     "images": [

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgfutur.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgfutur.json
@@ -119,7 +119,7 @@
             "rct2tt.scenery_small.fltsign1",
             "rct2tt.scenery_small.fltsign2"
         ],
-        "priority": 50,
+        "priority": 51,
         "entertainerCostumes": "astronaut"
     },
     "images": [

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgjurra.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgjurra.json
@@ -87,7 +87,7 @@
             "rct2tt.scenery_small.mamthw06",
             "rct2tt.scenery_large.caventra"
         ],
-        "priority": 25
+        "priority": 51
     },
     "images": [
         "$RCT2:OBJDATA/SCGJURRA.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgjurra.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgjurra.json
@@ -87,7 +87,7 @@
             "rct2tt.scenery_small.mamthw06",
             "rct2tt.scenery_large.caventra"
         ],
-        "priority": 51
+        "priority": 52
     },
     "images": [
         "$RCT2:OBJDATA/SCGJURRA.DAT[0..1]"

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmediv.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmediv.json
@@ -102,7 +102,7 @@
             "rct2tt.scenery_small.knfight1",
             "rct2tt.scenery_small.knfight2"
         ],
-        "priority": 25,
+        "priority": 52,
         "entertainerCostumes": "knight"
     },
     "images": [

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmediv.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmediv.json
@@ -102,7 +102,7 @@
             "rct2tt.scenery_small.knfight1",
             "rct2tt.scenery_small.knfight2"
         ],
-        "priority": 52,
+        "priority": 53,
         "entertainerCostumes": "knight"
     },
     "images": [

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmytho.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmytho.json
@@ -76,7 +76,7 @@
             "rct2tt.scenery_small.titansta",
             "rct2tt.scenery_small.zeusstat"
         ],
-        "priority": 53,
+        "priority": 54,
         "entertainerCostumes": "roman"
     },
     "images": [

--- a/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmytho.json
+++ b/objects/rct2tt/scenery_group/rct2tt.scenery_group.scgmytho.json
@@ -76,7 +76,7 @@
             "rct2tt.scenery_small.titansta",
             "rct2tt.scenery_small.zeusstat"
         ],
-        "priority": 25,
+        "priority": 53,
         "entertainerCostumes": "roman"
     },
     "images": [

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgafric.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgafric.json
@@ -114,7 +114,7 @@
             "rct2ww.scenery_large.3x3atre3",
             "rct2ww.scenery_large.3x3altre"
         ],
-        "priority": 25,
+        "priority": 40,
         "entertainerCostumes": "gorilla"
     },
     "images": [

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgafric.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgafric.json
@@ -114,7 +114,7 @@
             "rct2ww.scenery_large.3x3atre3",
             "rct2ww.scenery_large.3x3altre"
         ],
-        "priority": 40,
+        "priority": 41,
         "entertainerCostumes": "gorilla"
     },
     "images": [

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgartic.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgartic.json
@@ -56,7 +56,7 @@
             "rct2ww.scenery_small.pva",
             "rct2ww.scenery_large.sunken"
         ],
-        "priority": 41,
+        "priority": 42,
         "entertainerCostumes": "snowman"
     },
     "images": [

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgartic.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgartic.json
@@ -56,7 +56,7 @@
             "rct2ww.scenery_small.pva",
             "rct2ww.scenery_large.sunken"
         ],
-        "priority": 25,
+        "priority": 41,
         "entertainerCostumes": "snowman"
     },
     "images": [

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgasia.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgasia.json
@@ -114,7 +114,7 @@
             "rct2ww.scenery_small.rshogi2",
             "rct2ww.scenery_small.rshogi3"
         ],
-        "priority": 25
+        "priority": 42
     },
     "images": [
         "$RCT2:OBJDATA/SCGASIA.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgasia.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgasia.json
@@ -114,7 +114,7 @@
             "rct2ww.scenery_small.rshogi2",
             "rct2ww.scenery_small.rshogi3"
         ],
-        "priority": 42
+        "priority": 43
     },
     "images": [
         "$RCT2:OBJDATA/SCGASIA.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgaustr.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgaustr.json
@@ -51,7 +51,7 @@
             "rct2ww.scenery_small.fountrow",
             "rct2ww.scenery_small.fountarc"
         ],
-        "priority": 25
+        "priority": 43
     },
     "images": [
         "$RCT2:OBJDATA/SCGAUSTR.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgaustr.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgaustr.json
@@ -51,7 +51,7 @@
             "rct2ww.scenery_small.fountrow",
             "rct2ww.scenery_small.fountarc"
         ],
-        "priority": 43
+        "priority": 44
     },
     "images": [
         "$RCT2:OBJDATA/SCGAUSTR.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgeurop.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgeurop.json
@@ -133,7 +133,7 @@
             "rct2ww.scenery_small.wtudor18",
             "rct2ww.scenery_large.ovrgrwnt"
         ],
-        "priority": 44
+        "priority": 45
     },
     "images": [
         "$RCT2:OBJDATA/SCGEUROP.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgeurop.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgeurop.json
@@ -133,7 +133,7 @@
             "rct2ww.scenery_small.wtudor18",
             "rct2ww.scenery_large.ovrgrwnt"
         ],
-        "priority": 25
+        "priority": 44
     },
     "images": [
         "$RCT2:OBJDATA/SCGEUROP.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgnamrc.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgnamrc.json
@@ -123,7 +123,7 @@
             "rct2ww.scenery_large.1x4brg04",
             "rct2ww.scenery_large.1x4brg05"
         ],
-        "priority": 25,
+        "priority": 45,
         "entertainerCostumes": [
             "bandit",
             "sheriff"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgnamrc.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgnamrc.json
@@ -123,7 +123,7 @@
             "rct2ww.scenery_large.1x4brg04",
             "rct2ww.scenery_large.1x4brg05"
         ],
-        "priority": 45,
+        "priority": 46,
         "entertainerCostumes": [
             "bandit",
             "sheriff"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgsamer.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgsamer.json
@@ -104,7 +104,7 @@
             "rct2ww.scenery_large.gdstaue1",
             "rct2ww.scenery_large.gdstaue2"
         ],
-        "priority": 25
+        "priority": 46
     },
     "images": [
         "$RCT2:OBJDATA/SCGSAMRC.DAT[0..1]"

--- a/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgsamer.json
+++ b/objects/rct2ww/scenery_group/rct2ww.scenery_group.scgsamer.json
@@ -104,7 +104,7 @@
             "rct2ww.scenery_large.gdstaue1",
             "rct2ww.scenery_large.gdstaue2"
         ],
-        "priority": 46
+        "priority": 47
     },
     "images": [
         "$RCT2:OBJDATA/SCGSAMRC.DAT[0..1]"


### PR DESCRIPTION
Updated expansion scenery groups to sort after the base RCT2 groups in the scenery picker, instead of being sorted at random in the middle. The new order is:

- RCT2 groups, as before (1-39)
- Panda theming and any custom groups (40)
- WW alphabetically (41-47)
- TT alphabetically (48-54)
- Six Flags, as before (99)

![image](https://github.com/OpenRCT2/objects/assets/5436387/5d4bee16-71b5-4560-9ff5-cd52eb9ba86f)

Closes #244.
