### PR TITLE
Do not mark RCT2 toilet as available in RCT1

### DIFF
--- a/objects/rct2/ride/rct2.ride.tlt1.json
+++ b/objects/rct2/ride/rct2.ride.tlt1.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188B80|TLT1    |D53148B1",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "ride",
     "properties": {


### PR DESCRIPTION
It was marked as available in RCT1 before we ported over the _real_ RCT1 version. At the time, we simply forgot to undo this modification on the RCT2 version.