### PR TITLE
Removing the rct1 tag on 3 items and change 3 other object from rct1 tag to rct1ll tag

### DIFF
--- a/objects/rct2/scenery_small/rct2.scenery_small.allsort1.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.allsort1.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188C81|ALLSORT1|DFD73836",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.allsort2.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.allsort2.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188C81|ALLSORT2|FC5165C0",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.tct1.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tct1.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188D81|TCT1    |26E9E369",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.tct1.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tct1.json
@@ -8,6 +8,7 @@
     "originalId": "0A188D81|TCT1    |26E9E369",
     "sourceGame": [
         "rct2"
+        "rct1ll"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.tct2.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tct2.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188D81|TCT2    |21A44071",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.tct2.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tct2.json
@@ -8,6 +8,7 @@
     "originalId": "0A188D81|TCT2    |21A44071",
     "sourceGame": [
         "rct2"
+        "rct1ll"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.tly.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tly.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188E81|TLY     |6BE9844D",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_small/rct2.scenery_small.tly.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tly.json
@@ -8,6 +8,7 @@
     "originalId": "0A188E81|TLY     |6BE9844D",
     "sourceGame": [
         "rct2"
+        "rct1ll"
     ],
     "objectType": "scenery_small",
     "properties": {

--- a/objects/rct2/scenery_wall/rct2.scenery_wall.wmww.json
+++ b/objects/rct2/scenery_wall/rct2.scenery_wall.wmww.json
@@ -7,8 +7,7 @@
     "version": "1.0",
     "originalId": "0A188083|WMWW    |A7C87B33",
     "sourceGame": [
-        "rct2",
-        "rct1"
+        "rct2"
     ],
     "objectType": "scenery_wall",
     "properties": {

--- a/objects/rct2/scenery_wall/rct2.scenery_wall.wmww.json
+++ b/objects/rct2/scenery_wall/rct2.scenery_wall.wmww.json
@@ -8,6 +8,7 @@
     "originalId": "0A188083|WMWW    |A7C87B33",
     "sourceGame": [
         "rct2"
+        "rct1aa"
     ],
     "objectType": "scenery_wall",
     "properties": {


### PR DESCRIPTION
Objects that wasn't in rct1 at all (or uncertain) are:

-The 2 candy "roofs"
-The Small Jurassic Wall

Objects that wasn't in rct1 w/o dlc, but was in Loopy Landscapes are:

-The 2 Circular Castle Towers
-The Lily