### PR TITLE
Rename custom music and mark as compat objects

### DIFF
--- a/objects/rct2/music/rct2.music.custom1.json
+++ b/objects/rct2/music/rct2.music.custom1.json
@@ -8,6 +8,7 @@
         "rct2",
         "rct1ll"
     ],
+    "isCompatibilityObject": true,
     "objectType": "music",
     "properties": {
         "originalStyleId": 23,
@@ -20,7 +21,7 @@
     },
     "strings": {
         "name": {
-            "en-GB": "Custom music 1",
+            "en-GB": "Legacy custom music 1",
             "ca-ES": "Peça personalitzada 1",
             "cs-CZ": "Vlastní hudba 1",
             "da-DK": "Valgfrit musik 1",

--- a/objects/rct2/music/rct2.music.custom2.json
+++ b/objects/rct2/music/rct2.music.custom2.json
@@ -8,6 +8,7 @@
         "rct2",
         "rct1ll"
     ],
+    "isCompatibilityObject": true,
     "objectType": "music",
     "properties": {
         "originalStyleId": 24,
@@ -20,7 +21,7 @@
     },
     "strings": {
         "name": {
-            "en-GB": "Custom music 2",
+            "en-GB": "Legacy custom music 2",
             "ca-ES": "Peça personalitzada 2",
             "cs-CZ": "Vlastní hudba 2",
             "da-DK": "Valgfrit musik 2",


### PR DESCRIPTION
Renames both of the custom music 1/2 styles to legacy custom music 1/2 and marks them as compatibility objects.

Closes #228