### PR TITLE
Re-introduce RCT1 road

### DIFF
--- a/objects/rct1/footpath_surface/rct1.footpath_surface.road/object.json
+++ b/objects/rct1/footpath_surface/rct1.footpath_surface.road/object.json
@@ -1,17 +1,18 @@
 {
-    "id": "rct2.footpath_surface.road",
+    "id": "rct1.footpath_surface.road",
     "authors": [
         "Chris Sawyer",
         "Simon Foster"
     ],
     "version": "1.0",
     "sourceGame": [
+        "rct1",
         "rct2"
     ],
     "objectType": "footpath_surface",
-    "isCompatibilityObject": true,
     "properties": {
-        "editorOnly": true
+        "editorOnly": true,
+        "noSlopeRailings": true
     },
     "images": [
         "$RCT2:OBJDATA/ROAD.DAT[71]",


### PR DESCRIPTION
The RCT2 road draws handrails in the tunnels and on slopes (because RCT2 was programmed to do this with all paths), which makes it look weird and also means that roads in RCT1 scenarios don’t always look like they should.

Here are the two side by side (RCT2 on the left, RCT1 on the right):

![afbeelding](https://github.com/OpenRCT2/objects/assets/1478678/7662c7a0-af28-4f6d-a315-9f1df27a1942)
