### PR TITLE
Fix wall detection for TT automobile large scenery

### DIFF
--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.1950scar.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.1950scar.json
@@ -20,14 +20,14 @@
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.gbeetlex.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.gbeetlex.json
@@ -19,14 +19,14 @@
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.ghotrod1.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.ghotrod1.json
@@ -19,14 +19,14 @@
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.ghotrod2.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.ghotrod2.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.gschlbus.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.gschlbus.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.peramob1.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.peramob1.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.peramob2.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.peramob2.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.perdtk01.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.perdtk01.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.perdtk02.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.perdtk02.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 24,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.travlr01.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.travlr01.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 56,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 56,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },

--- a/objects/rct2tt/scenery_large/rct2tt.scenery_large.travlr02.json
+++ b/objects/rct2tt/scenery_large/rct2tt.scenery_large.travlr02.json
@@ -18,14 +18,14 @@
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 9
+                "walls": 11
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 32,
                 "hasSupports": true,
-                "walls": 3
+                "walls": 14
             }
         ]
     },


### PR DESCRIPTION
I initially wanted to make this a more thorough set of fixes on a per scenery group basis but times have changed so i don't believe i'm going to be doing that any time soon so i just want to submit the fixes i already have for the main objects where this is relevant.

Fixes the wall detection for TT's automobile scenery from the roaring twenties + rock & roll theming, as previously the detection was faulty. Now you can properly place scenery walls around them.

![Screenshot_select-area_20240114165716](https://github.com/OpenRCT2/objects/assets/42477864/12101bc4-0669-4054-a158-d9db6b844056)
![Screenshot_select-area_20240114165722](https://github.com/OpenRCT2/objects/assets/42477864/89ab3064-e46e-42db-92ad-fb84e9fb7476)
