### PR TITLE
Remove improper voffset flags

### DIFF
--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.stmdran1.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.stmdran1.json
@@ -16,7 +16,6 @@
         "animationMask": 15,
         "numFrames": 16,
         "shape": "4/4",
-        "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "isRotatable": true,
         "isAnimated": true,
         "isStackable": true,

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.wiskybl1.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.wiskybl1.json
@@ -13,7 +13,6 @@
         "cursor": "CURSOR_STATUE_DOWN",
         "height": 16,
         "shape": "4/4",
-        "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
         "isStackable": true

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.babyele.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.babyele.json
@@ -13,7 +13,6 @@
         "cursor": "CURSOR_STATUE_DOWN",
         "height": 32,
         "shape": "4/4",
-        "SMALL_SCENERY_FLAG_VOFFSET_CENTRE": true,
         "requiresFlatSurface": true,
         "isRotatable": true,
         "hasPrimaryColour": true,


### PR DESCRIPTION
Most small scenery objects in WW/TT seem to have this flag, but these three scenery pieces weren't designed with it in mind so their sprites are improperly offset upwards which would cause their sprites to shift positions when rotating your view. Removing the flag fixes this.

Oil barrel on green tile is for reference, it's not changed
Before:
![Screenshot_select-area_20240115093546](https://github.com/OpenRCT2/objects/assets/42477864/3234ba8a-32d4-4666-bf69-17aed1dc4187)

After:
![Screenshot_select-area_20240115093456](https://github.com/OpenRCT2/objects/assets/42477864/1fd4ca88-7006-4bdb-a41b-d21cf81597db)
