### PR TITLE
Fix TT mini suspended diagonals

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.dragnfly.json
+++ b/objects/rct2tt/ride/rct2tt.ride.dragnfly.json
@@ -43,10 +43,12 @@
             "frictionSoundId": 2,
             "soundRange": 0,
             "drawOrder": 2,
-            "frames": {
-                "flat": true,
-                "gentleSlopes": true,
-                "diagonalSlopes": true
+            "spriteGroups": {
+                "slopeFlat": 32,
+                "slopes12": 4,
+                "slopes25": 32,
+                "slopes8": 4,
+                "slopes16": 4
             },
             "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
@@ -59,7 +61,46 @@
         }
     },
     "images": [
-        "$RCT2:OBJDATA/DRAGNFLY.DAT[0..1282]"
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[0]",
+        "",
+        "",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[3..537]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[543..546]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[542]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[548..552]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[558..560]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[556..557]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[563..572]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[578..581]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[577]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[583..587]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[593..595]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[591..592]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[598..607]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[613..616]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[612]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[618..622]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[628]",
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[624..627]",
+
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[643..1177]",                                                                                                                                                                               
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1183..1186]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1182]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1188..1192]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1198..1200]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1196..1197]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1203..1212]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1218..1221]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1217]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1223..1227]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1233..1235]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1231..1232]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1238..1247]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1253..1256]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1252]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1258..1262]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1268]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/DRAGNFLY.DAT[1264..1267]"
     ],
     "strings": {
         "name": {

--- a/objects/rct2tt/ride/rct2tt.ride.hovrbord.json
+++ b/objects/rct2tt/ride/rct2tt.ride.hovrbord.json
@@ -43,10 +43,12 @@
             "frictionSoundId": 2,
             "soundRange": 0,
             "drawOrder": 2,
-            "frames": {
-                "flat": true,
-                "gentleSlopes": true,
-                "diagonalSlopes": true
+            "spriteGroups": {
+                "slopeFlat": 32,
+                "slopes12": 4,
+                "slopes25": 32,
+                "slopes8": 4,
+                "slopes16": 4
             },
             "hasAdditionalColour1": true,
             "hasSwinging": true,
@@ -58,7 +60,46 @@
         }
     },
     "images": [
-        "$RCT2:OBJDATA/HOVRBORD.DAT[0..1282]"
+        "$RCT2:OBJDATA/HOVRBORD.DAT[0]",
+        "",
+        "",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[3..537]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[543..546]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[542]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[548..552]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[558..560]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[556..557]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[563..572]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[578..581]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[577]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[583..587]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[593..595]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[591..592]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[598..607]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[613..616]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[612]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[618..622]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[628]",
+        "$RCT2:OBJDATA/HOVRBORD.DAT[624..627]",
+
+        "$RCT2:OBJDATA/HOVRBORD.DAT[643..1177]",                                                                                                                                                                               
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1183..1186]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1182]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1188..1192]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1198..1200]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1196..1197]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1203..1212]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1218..1221]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1217]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1223..1227]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1233..1235]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1231..1232]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1238..1247]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1253..1256]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1252]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1258..1262]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1268]",                                                                                                                                                                                    
+        "$RCT2:OBJDATA/HOVRBORD.DAT[1264..1267]"
     ],
     "strings": {
         "name": {


### PR DESCRIPTION
Fixes the diagonal incline sprites for the TT hoverboard & dragon fly cars for the mini suspended coaster. All of the needed sprites for slopes 8 and 16 were there but just scrambled up with tons of duplicates.

Slopes 50 had to be removed with new spritegroups as the sprites for it quite literally do not exist in the object dat, but that isn't a big deal as the ride type only uses 8 and 16 nor were the 50 sprites functional in the first place due to the mangled sprite order and previously mentioned non-existent sprites.

![Screenshot_select-area_20240115115713](https://github.com/OpenRCT2/objects/assets/42477864/055b46b0-8cbc-4d17-9cd3-f7c35f644767)
![Screenshot_select-area_20240115115721](https://github.com/OpenRCT2/objects/assets/42477864/e58ebf70-f6a0-4dfd-986d-4c74afa46285)
![Screenshot_select-area_20240115121717](https://github.com/OpenRCT2/objects/assets/42477864/90d3d966-e8d1-4c0b-ba0b-3c09c5257490)

The sputnik cars suffer from a completely separate issue so they are not touched by this PR.

Fixes #58