### PR TITLE
Fix sputnik cars diagonal inclines

### DIFF
--- a/objects/rct2ww/ride/rct2ww.ride.sputnikr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.sputnikr.json
@@ -43,10 +43,12 @@
             "frictionSoundId": 2,
             "soundRange": 0,
             "drawOrder": 2,
-            "frames": {
-                "flat": true,
-                "gentleSlopes": true,
-                "diagonalSlopes": true
+            "spriteGroups": {
+                "slopeFlat": 32,
+                "slopes12": 4,
+                "slopes25": 32,
+                "slopes8": 4,
+                "slopes16": 4
             },
             "hasAdditionalColour1": true,
             "hasSwinging": true,
@@ -58,7 +60,44 @@
         }
     },
     "images": [
-        "$RCT2:OBJDATA/SPUTNIKR.DAT[0..1282]"
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[0]",
+        "",
+        "",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[3..522]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[223..227]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[263..267]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[303..307]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[343..347]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[383..387]",                                                                                                                                                                                  
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[423..427]",                                                                                                                                                                                  
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[463..467]",                                                                                                                                                                                  
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[503..507]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[223..227]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[263..267]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[303..307]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[343..347]",
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[383..387]",                                                                                                                                                                                  
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[423..427]",                                                                                                                                                                                  
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[463..467]",                                                                                                                                                                                  
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[503..507]",
+        
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[643..1162]",                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[863..867]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[903..907]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[943..947]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[983..987]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1023..1027]",                                                                                                                                                                                                                                                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1063..1067]",                                                                                                                                                                                                                                                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1103..1107]",                                                                                                                                                                                                                                                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1143..1147]",                                                                                                                                                                              
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[863..867]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[903..907]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[943..947]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[983..987]",                                                                                                                                                                                
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1023..1027]",                                                                                                                                                                                                                                                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1063..1067]",                                                                                                                                                                                                                                                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1103..1107]",                                                                                                                                                                                                                                                                                                                                                                                                               
+        "$RCT2:OBJDATA/SPUTNIKR.DAT[1143..1147]"
     ],
     "strings": {
         "name": {


### PR DESCRIPTION
Fixes the sputnik diagonal incline sprites by making them re-use sprites from slopes25, it's not ideal but it's the best that can be done with the original graphics. Incase you're wondering, i did try it with just a single set of slopes8 sprites but slopes16 would still fallback to flat sprites so i had to duplicate the sprites in the images table.

The guest sprites for this vehicle are very terribly done, so it's not an error with this PR. (Yes there are guests in the vehicles in these previews)

![Screenshot_select-area_20240115173121](https://github.com/OpenRCT2/objects/assets/42477864/b0106f72-a0c6-497c-aaa2-f676d075eb0b)
![Screenshot_select-area_20240115173128](https://github.com/OpenRCT2/objects/assets/42477864/2ffba24f-67ff-47a6-aed2-1a570e95e9fd)


Fixes #264