### PR TITLE
Fix third colors for valkyrie & condor trains (again)

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
+++ b/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
@@ -17,7 +17,7 @@
                 [
                     "black",
                     "black",
-                    "light_brown"
+                    "yellow"
                 ]
             ]
         ],

--- a/objects/rct2ww/ride/rct2ww.ride.condorrd.json
+++ b/objects/rct2ww/ride/rct2ww.ride.condorrd.json
@@ -18,14 +18,14 @@
                 [
                     "bright_red",
                     "yellow",
-                    "dark_purple"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "teal",
                     "grey",
-                    "dark_purple"
+                    "yellow"
                 ]
             ]
         ],


### PR DESCRIPTION
While i fixed these objects in the past, recently it was brought to my attention that the yellow colors are used for handling the third remap. So while the colors i chose were decent enough the colors still weren't the intended colors for the object. So i've changed their third colors in all of their default presets to yellow.

For the condor trains the difference is barely noticeable as only a few stray pixels on a few sprites (which are a part of the yellow highlights on the vehicles) are affected by the third remap.

For the valkyrie trains the difference is much more noticeable as it affects the hair of the valkyries.
Valkyrie sprite exported (How it was intended to look ingame before the yellow remap broke it)
![0003](https://github.com/OpenRCT2/objects/assets/42477864/fdc31000-1298-4a8f-acba-36369bccf066)

Valkyrie with third remap set to yellow.
![Screenshot_select-area_20240116093830](https://github.com/OpenRCT2/objects/assets/42477864/5b3cd056-4d58-437c-9419-a570c9379197)

Note that the third remaps for both of these vehicles are still locked, and that this will only affect the look of new instances of these vehicles in parks as old ones will preserve their old colors.