### PR TITLE
Remove supports from large ice formation pieces

### DIFF
--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.icefor01.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.icefor01.json
@@ -17,112 +17,96 @@
                 "x": 0,
                 "y": 0,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 9
             },
             {
                 "x": 0,
                 "y": 32,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 3
             },
             {
                 "x": 0,
                 "y": 64,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 9
             },
             {
                 "x": 0,
                 "y": 96,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 3
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 32,
                 "y": 64,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 32,
                 "y": 96,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 64,
                 "y": 0,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 64,
                 "y": 32,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 64,
                 "y": 64,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 64,
                 "y": 96,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 96,
                 "y": 0,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 12
             },
             {
                 "x": 96,
                 "y": 32,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 6
             },
             {
                 "x": 96,
                 "y": 64,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 12
             },
             {
                 "x": 96,
                 "y": 96,
                 "clearance": 152,
-                "hasSupports": true,
                 "walls": 6
             }
         ]

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.icefor02.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.icefor02.json
@@ -17,112 +17,96 @@
                 "x": 0,
                 "y": 0,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 9
             },
             {
                 "x": 0,
                 "y": 32,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 3
             },
             {
                 "x": 0,
                 "y": 64,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 9
             },
             {
                 "x": 0,
                 "y": 96,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 3
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 32,
                 "y": 64,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 32,
                 "y": 96,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 64,
                 "y": 0,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 64,
                 "y": 32,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 64,
                 "y": 64,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 8
             },
             {
                 "x": 64,
                 "y": 96,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 2
             },
             {
                 "x": 96,
                 "y": 0,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 12
             },
             {
                 "x": 96,
                 "y": 32,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 6
             },
             {
                 "x": 96,
                 "y": 64,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 12
             },
             {
                 "x": 96,
                 "y": 96,
                 "clearance": 208,
-                "hasSupports": true,
                 "walls": 6
             }
         ]


### PR DESCRIPTION
Removes supports from the WW large ice formation scenery pieces.

![Screenshot_select-area_20240123174148](https://github.com/OpenRCT2/objects/assets/42477864/ace39035-55fa-4831-864e-691355fa2963)

Closes #269