### PR TITLE
Add empty car property to tgv trains

### DIFF
--- a/objects/rct2ww/ride/rct2ww.ride.tgvtrain.json
+++ b/objects/rct2ww/ride/rct2ww.ride.tgvtrain.json
@@ -13,6 +13,7 @@
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 3,
         "maxCarsPerTrain": 8,
+        "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,
         "tailCars": 2,


### PR DESCRIPTION
The TGV lim coaster trains have an added third, empty car (like the corkscrew coaster back car) that that base game lim trains don't have. However when frontier added this they didn't add the empty car property to the object which would count the empty car when displaying the number of cars per train in the build menu. This fixes that.