### PR TITLE
Disallow building RCT1 brown fence gate on slopes

### DIFF
--- a/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown_gate.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown_gate.json
@@ -7,13 +7,12 @@
     "objectType": "scenery_wall",
     "properties": {
         "hasPrimaryColour": true,
-        "isAllowedOnSlope": true,
         "height": 2,
         "price": 40,
         "sceneryGroup": "rct2.scenery_group.scgfence"
     },
-    "images": ["$CSG[63155..63160]"],
-    "noCsgImages": ["$RCT2:OBJDATA/WPW1.DAT[0..5]"],
+    "images": ["$CSG[63155..63156]"],
+    "noCsgImages": ["$RCT2:OBJDATA/WPW1.DAT[0..1]"],
     "strings": {
         "name": {
             "en-GB": "Wooden Fence",


### PR DESCRIPTION
With how https://github.com/OpenRCT2/OpenRCT2/pull/21278 was implemented, the flag and sprites are not needed anymore on this object. Since these new objects have not been in an objects release yet it should be okay to do this.