### PR TITLE
Mark reversed trains as compat objects

### DIFF
--- a/objects/rct1/ride/rct1.ride.steel_rc_trains_reversed/object.json
+++ b/objects/rct1/ride/rct1.ride.steel_rc_trains_reversed/object.json
@@ -7,6 +7,7 @@
     "version": "1.0",
     "originalId": "00000000|#RCT1STR|00000000",
     "sourceGame": "rct1",
+    "isCompatibilityObject": true,
     "objectType": "ride",
     "properties": {
         "type": "looping_rc",

--- a/objects/rct1/ride/rct1.ride.wooden_rc_trains_reversed/object.json
+++ b/objects/rct1/ride/rct1.ride.wooden_rc_trains_reversed/object.json
@@ -7,6 +7,7 @@
     "version": "1.0",
     "originalId": "00000000|#RCT1PTR|00000000",
     "sourceGame": "rct1",
+    "isCompatibilityObject": true,
     "objectType": "ride",
     "properties": {
         "type": "classic_wooden_rc",

--- a/objects/rct2/ride/rct2.ride.ptct2r.json
+++ b/objects/rct2/ride/rct2.ride.ptct2r.json
@@ -7,6 +7,7 @@
     "version": "1.1",
     "originalId": "0A188B80|PTCT2R  |4433BD4C",
     "sourceGame": "rct2",
+    "isCompatibilityObject": true,
     "objectType": "ride",
     "properties": {
         "type": "wooden_rc",

--- a/objects/rct2/ride/rct2.ride.utcarr.json
+++ b/objects/rct2/ride/rct2.ride.utcarr.json
@@ -10,6 +10,7 @@
         "rct2",
         "rct1aa"
     ],
+    "isCompatibilityObject": true,
     "objectType": "ride",
     "properties": {
         "type": "heartline_twister_rc",


### PR DESCRIPTION
Marks all of the reversed trains as compat objects.

These objects should probably still be removed eventually with more advanced import code, but this should work fine for now.

Fixes #273