### PR TITLE
Fix pricing & map colors of RCT1 roof surfaces

### DIFF
--- a/objects/rct1/terrain_surface/rct1aa.terrain_surface.roof_red/object.json
+++ b/objects/rct1/terrain_surface/rct1aa.terrain_surface.roof_red/object.json
@@ -9,10 +9,10 @@
     "sourceGame": "rct1aa",
     "objectType": "terrain_surface",
     "properties": {
-        "price": 100,
+        "price": 120,
         "mapColours": [
-            113,
-            113
+            111,
+            111
         ]
     },
     "images": [

--- a/objects/rct1/terrain_surface/rct1ll.terrain_surface.roof_grey/object.json
+++ b/objects/rct1/terrain_surface/rct1ll.terrain_surface.roof_grey/object.json
@@ -9,9 +9,9 @@
     "sourceGame": "rct1ll",
     "objectType": "terrain_surface",
     "properties": {
-        "price": 100,
+        "price": 120,
         "mapColours": [
-            10,
+            17,
             16
         ]
     },

--- a/objects/rct1/terrain_surface/rct1ll.terrain_surface.rust/object.json
+++ b/objects/rct1/terrain_surface/rct1ll.terrain_surface.rust/object.json
@@ -9,10 +9,10 @@
     "sourceGame": "rct1ll",
     "objectType": "terrain_surface",
     "properties": {
-        "price": 100,
+        "price": 120,
         "mapColours": [
-            108,
-            108
+            41,
+            219
         ],
         "special": [
             {

--- a/objects/rct1/terrain_surface/rct1ll.terrain_surface.wood/object.json
+++ b/objects/rct1/terrain_surface/rct1ll.terrain_surface.wood/object.json
@@ -9,10 +9,10 @@
     "sourceGame": "rct1ll",
     "objectType": "terrain_surface",
     "properties": {
-        "price": 100,
+        "price": 120,
         "mapColours": [
-            108,
-            108
+            41,
+            39
         ],
         "special": [
             {


### PR DESCRIPTION
The metadata of these were incorrect, the prices of all the roof tiles in RCT1 was $12 and the map colors were different. This fixes them to be accurate to RCT1

RCT1:
![Screenshot_select-area_20240212220845](https://github.com/OpenRCT2/objects/assets/42477864/54adfd79-6150-4498-91dd-4a4284b59bf4)
![Screenshot_select-area_20240212222627](https://github.com/OpenRCT2/objects/assets/42477864/c232c5b7-7196-49a8-a0e6-c334424a96a5)

OpenRCT2 after fixes:
![Screenshot_select-area_20240212222607](https://github.com/OpenRCT2/objects/assets/42477864/99233ac1-584e-4764-bc92-c00aa35663f4)
