### PR TITLE
Remove non-functional third remap from hmcar

### DIFF
--- a/objects/rct2/ride/rct2.ride.hmcar.json
+++ b/objects/rct2/ride/rct2.ride.hmcar.json
@@ -80,7 +80,7 @@
                 "isPoweredRideWithUnrestrictedGravity": true,
                 "hasNoUpstopWheels": true,
                 "hasNoUpstopWheelsBobsleigh": true,
-                "hasAdditionalColour2": true,
+                "hasAdditionalColour1": true,
                 "isPowered": true
             }
         ],


### PR DESCRIPTION
The haunted mansion cars have an erroneous third remap enabled that doesn't do anything, this remap is only enabled by the invisible cars as they accidentally had the 2nd additional colour flag set rather than the 1st which is what the normal car uses. This PR fixes that.

Before:
![Screenshot_select-area_20240215214206](https://github.com/OpenRCT2/objects/assets/42477864/08ffa215-b4bf-436b-8e58-7ac30be45237)
After:
![Screenshot_select-area_20240215232927](https://github.com/OpenRCT2/objects/assets/42477864/8868981d-0056-4d55-8037-609bff17c6a8)
