### PR TITLE
Add flipped version of post scenery wall

### DIFF
--- a/objects/official/scenery_wall/official.scenery_wall.post_flipped.json
+++ b/objects/official/scenery_wall/official.scenery_wall.post_flipped.json
@@ -1,0 +1,44 @@
+{
+    "id": "official.scenery_wall.post_flipped",
+    "authors": [
+        "OpenRCT2 developers",
+        "Simon Foster"
+    ],
+    "version": "1.0",
+    "sourceGame": "official",
+    "objectType": "scenery_wall",
+    "properties": {
+        "isBanner": true,
+        "hasPrimaryColour": true,
+        "height": 4,
+        "price": 70
+    },
+    "images": [
+        "$RCT2:OBJDATA/WALLPOST.DAT[6..7]",
+        "",
+        "",
+        "",
+        "",
+        "$RCT2:OBJDATA/WALLPOST.DAT[0..1]"
+    ],
+    "strings": {
+        "name": {
+            "en-GB": "Post",
+            "fr-FR": "Poteau",
+            "de-DE": "Pfosten",
+            "es-ES": "Poste",
+            "it-IT": "Sostegno",
+            "ko-KR": "기둥",
+            "zh-CN": "柱子",
+            "zh-TW": "柱子",
+            "pt-BR": "Estaca",
+            "cs-CZ": "Sloup",
+            "ja-JP": "柱",
+            "nl-NL": "Paal",
+            "pl-PL": "Słupek",
+            "ru-RU": "Пост",
+            "eo-ZZ": "Fosto",
+            "fi-FI": "Tolppa"
+        }
+    }
+}

--- a/objects/rct2/scenery_group/rct2.scenery_group.scgpathx.json
+++ b/objects/rct2/scenery_group/rct2.scenery_group.scgpathx.json
@@ -20,6 +20,7 @@
             "rct2.footpath_item.qtv1",
             "rct2.footpath_banner.bn1",
             "rct2.scenery_wall.wallpost",
+            "official.scenery_wall.post_flipped",
             "rct2.scenery_wall.wallsign",
             "rct2.scenery_large.ssig1",
             "rct2.scenery_large.ssig2",


### PR DESCRIPTION
Adds a flipped version of the post scenery wall as an official scenery addition, this doesn't require any new sprites as they can just be read from the original object's dat.

![Screenshot_select-area_20240219203247](https://github.com/OpenRCT2/objects/assets/42477864/06c78181-df18-45ea-9905-2249752e177e)

Curiously, scenery walls reserve image slots for sloped images even when they're not enabled by the object. this is why there is 4 empty images in the images table.