### PR TITLE
Accurate ratingmultiplers for RCT1 vehicles

### DIFF
--- a/objects/rct1/ride/rct1.ride.bumper_boats/object.json
+++ b/objects/rct1/ride/rct1.ride.bumper_boats/object.json
@@ -13,9 +13,9 @@
             "thrill"
         ],
         "ratingMultipler": {
-            "excitement": 30,
-            "intensity": 15,
-            "nausea": 15
+            "excitement": 40,
+            "intensity": 32,
+            "nausea": 30
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1.ride.horses/object.json
+++ b/objects/rct1/ride/rct1.ride.horses/object.json
@@ -9,9 +9,6 @@
     "properties": {
         "type": "steeplechase",
         "category": "rollercoaster",
-        "ratingMultipler": {
-            "excitement": 5
-        },
         "carColours": [
             [
                 ["white", "bright_red", "black"]

--- a/objects/rct1/ride/rct1.ride.mine_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.mine_cars/object.json
@@ -19,7 +19,7 @@
         "headCars": 1,
         "tailCars": 1,
         "ratingMultipler": {
-            "intensity": 3
+            "intensity": 2
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1.ride.motorbikes/object.json
+++ b/objects/rct1/ride/rct1.ride.motorbikes/object.json
@@ -9,9 +9,6 @@
     "properties": {
         "type": "steeplechase",
         "category": "rollercoaster",
-        "ratingMultipler": {
-            "excitement": 3
-        },
         "carColours": [
             [
                 ["bright_red", "white", "black"]

--- a/objects/rct1/ride/rct1.ride.mouse_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.mouse_cars/object.json
@@ -19,7 +19,7 @@
         "headCars": 1,
         "tailCars": 1,
         "ratingMultipler": {
-            "excitement": 3
+            "excitement": 2
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1.ride.small_monorail_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.small_monorail_cars/object.json
@@ -17,7 +17,7 @@
         "tabScale": 0.5,
         "maxCarsPerTrain": 6,
         "ratingMultipler": {
-            "excitement": 3
+            "excitement": 6
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1.ride.steam_trains/object.json
+++ b/objects/rct1/ride/rct1.ride.steam_trains/object.json
@@ -20,9 +20,6 @@
             0,
             1
         ],
-        "ratingMultipler": {
-            "excitement": 3
-        },
         "carColours": [
             [
                 ["bright_red", "moss_green", "yellow"]

--- a/objects/rct1/ride/rct1.ride.streamlined_monorail_trains/object.json
+++ b/objects/rct1/ride/rct1.ride.streamlined_monorail_trains/object.json
@@ -19,6 +19,9 @@
         "maxCarsPerTrain": 8,
         "headCars": 1,
         "tailCars": 2,
+        "ratingMultipler": {
+            "intensity": 20
+        },
         "carColours": [
             [
                 [

--- a/objects/rct1/ride/rct1.ride.suspended_swinging_aeroplane_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.suspended_swinging_aeroplane_cars/object.json
@@ -15,8 +15,7 @@
         "tabScale": 0.5,
         "maxCarsPerTrain": 8,
         "ratingMultipler": {
-            "excitement": 5,
-            "nausea": 3
+            "excitement": 2
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1.ride.swinging_lay_down_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.swinging_lay_down_cars/object.json
@@ -15,9 +15,9 @@
         "minCarsPerTrain": 1,
         "maxCarsPerTrain": 2,
         "ratingMultipler": {
-            "excitement": 10,
-            "intensity": 25,
-            "nausea": 15
+            "excitement": 13,
+            "intensity": 20,
+            "nausea": 12
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1aa.ride.floorless_twister_trains/object.json
+++ b/objects/rct1/ride/rct1aa.ride.floorless_twister_trains/object.json
@@ -16,9 +16,9 @@
         "minCarsPerTrain": 4,
         "maxCarsPerTrain": 8,
         "ratingMultipler": {
-            "excitement": 10,
-            "intensity": 5,
-            "nausea": 10
+            "excitement": 3,
+            "intensity": 6,
+            "nausea": 8
         },
         "maxHeight": 34,
         "carColours": [

--- a/objects/rct1/ride/rct1aa.ride.hyper_twister_trains/object.json
+++ b/objects/rct1/ride/rct1aa.ride.hyper_twister_trains/object.json
@@ -19,8 +19,9 @@
         "tabCar": 1,
         "headCars": 1,
         "ratingMultipler": {
-            "excitement": 15,
-            "intensity": 3
+            "excitement": 22,
+            "intensity": 5,
+            "nausea": 5
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1aa.ride.ski_lift_cars/object.json
+++ b/objects/rct1/ride/rct1aa.ride.ski_lift_cars/object.json
@@ -10,8 +10,9 @@
         "type": "chairlift",
         "category": "transport",
         "ratingMultipler": {
-            "intensity": 3,
-            "nausea": 4
+            "excitement": 4,
+            "intensity": 36,
+            "nausea": 18
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1aa.ride.stand_up_twister_trains/object.json
+++ b/objects/rct1/ride/rct1aa.ride.stand_up_twister_trains/object.json
@@ -19,9 +19,9 @@
         "tabCar": 1,
         "headCars": 1,
         "ratingMultipler": {
-            "excitement": 2,
-            "intensity": 15,
-            "nausea": 10
+            "excitement": 1,
+            "intensity": 24,
+            "nausea": 22
         },
         "maxHeight": 40,
         "carColours": [

--- a/objects/rct1/ride/rct1ll.ride.4_across_inverted_trains/object.json
+++ b/objects/rct1/ride/rct1ll.ride.4_across_inverted_trains/object.json
@@ -15,6 +15,9 @@
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 4,
         "maxCarsPerTrain": 9,
+        "ratingMultipler": {
+            "excitement": 5
+        },
         "carColours": [
             [
                 [

--- a/objects/rct1/ride/rct1ll.ride.face_off_cars/object.json
+++ b/objects/rct1/ride/rct1ll.ride.face_off_cars/object.json
@@ -13,9 +13,9 @@
         "minCarsPerTrain": 2,
         "maxCarsPerTrain": 7,
         "ratingMultipler": {
-            "excitement": 8,
-            "intensity": 12,
-            "nausea": 10
+            "excitement": 6,
+            "intensity": 2,
+            "nausea": 9
         },
         "carColours": [
             [

--- a/objects/rct1/ride/rct1ll.ride.hypercoaster_trains/object.json
+++ b/objects/rct1/ride/rct1ll.ride.hypercoaster_trains/object.json
@@ -15,7 +15,9 @@
         "defaultCar": 1,
         "headCars": 0,
         "ratingMultipler": {
-            "excitement": 15
+            "excitement": 10,
+            "intensity": -6,
+            "nausea": -6
         },
         "maxHeight": 45,
         "carColours": [

--- a/objects/rct1/ride/rct1ll.ride.jet_skis/object.json
+++ b/objects/rct1/ride/rct1ll.ride.jet_skis/object.json
@@ -13,9 +13,9 @@
             "thrill"
         ],
         "ratingMultipler": {
-            "excitement": 75,
-            "intensity": 75,
-            "nausea": 40
+            "excitement": 44,
+            "intensity": 96,
+            "nausea": -5
         },
         "carColours": [
             [


### PR DESCRIPTION
These aren't quite perfect as the way RCT1 handled different vehicle stats seems to have been to have dedicated calculation functions for each vehicle on each ride type they're available for, so these are only close approximations with the ratingmultipler system we have. This should be close enough for the most part. For ride types where their base stats were changed in RCT2 (eg: compact invert) i've based the multiplers off of restored RCT1 base stats to keep things relative, so a 10% excitement modifier with RCT1 base stats will still be 10% modifier with the RCT2 stats. As a result some vehicles may still have more or less stats than they would in RCT1 but this should keep them mostly in line with how they were in RCT1 relatively at least.

There are three objects with multiplers that have special cases that i feel should be mentioned and they are:

1. The stand-up twister trains seem to get a lot more stats from g-forces in RCT1, this can't be emulated with ratingmultiplers so these will probably have the most variation compared to their original stats in RCT1. but it should be mostly close enough for the most part, some designs may just have less intensity & nausea than RCT1. I made sure that grapevine in funtopia matched closely at least as it's probably the most important design using these trains.
2. The bumper boats are a bit odd as the boat hire had much lower base intensity & nausea stats along with higher base excitement in RCT1. For this one i've ditched the relative approach as it didn't make much sense here and decided to just match the excitement & nausea while making sure that the intensity was roughly .20 points higher which is how it is in RCT1.
3. The jet skis are a completely separate ride type in RCT1, as such i've tried to emulate it's ratings directly with ratingmultiplers rather than using the relative approach.

Closes #297