### PR TITLE
Fix colosseum & volcano corner clearances

### DIFF
--- a/objects/rct2/scenery_large/rct2.scenery_large.scol.json
+++ b/objects/rct2/scenery_large/rct2.scenery_large.scol.json
@@ -30,16 +30,14 @@
                 "y": 32,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 11
+                "walls": 5
             },
             {
                 "x": 0,
                 "y": 64,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 7
+                "walls": 5
             },
             {
                 "x": 0,
@@ -54,16 +52,14 @@
                 "y": 96,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 7
+                "walls": 10
             },
             {
                 "x": 64,
                 "y": 96,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 14
+                "walls": 10
             },
             {
                 "x": 96,
@@ -78,16 +74,14 @@
                 "y": 64,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 14
+                "walls": 5
             },
             {
                 "x": 96,
                 "y": 32,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 13
+                "walls": 5
             },
             {
                 "x": 96,
@@ -102,16 +96,14 @@
                 "y": 0,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 13
+                "walls": 10
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 72,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 11
+                "walls": 10
             }
         ]
     },

--- a/objects/rct2/scenery_large/rct2.scenery_large.svlc.json
+++ b/objects/rct2/scenery_large/rct2.scenery_large.svlc.json
@@ -19,96 +19,84 @@
                 "y": 0,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 9,
-                "corners": 1
+                "walls": 9
             },
             {
                 "x": 0,
                 "y": 32,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 11
+                "walls": 5
             },
             {
                 "x": 0,
                 "y": 64,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 7
+                "walls": 5
             },
             {
                 "x": 0,
                 "y": 96,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 3,
-                "corners": 2
+                "walls": 3
             },
             {
                 "x": 32,
                 "y": 96,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 7
+                "walls": 10
             },
             {
                 "x": 64,
                 "y": 96,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 14
+                "walls": 10
             },
             {
                 "x": 96,
                 "y": 96,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 6,
-                "corners": 4
+                "walls": 6
             },
             {
                 "x": 96,
                 "y": 64,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 14
+                "walls": 5
             },
             {
                 "x": 96,
                 "y": 32,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 5,
-                "corners": 13
+                "walls": 5
             },
             {
                 "x": 96,
                 "y": 0,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 12,
-                "corners": 8
+                "walls": 12
             },
             {
                 "x": 64,
                 "y": 0,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 13
+                "walls": 10
             },
             {
                 "x": 32,
                 "y": 0,
                 "clearance": 64,
                 "hasSupports": true,
-                "walls": 10,
-                "corners": 11
+                "walls": 10
             }
         ]
     },


### PR DESCRIPTION
The colosseum & volcano large scenery items have some buggy clearances related to the "corners" property.

Firstly, the volcano uses this flag erroneously as it was just cloned from the colosseum so i've just removed it from all of the tiles it had as all of it's sprites take up the entirety of their tiles.

Secondly, the colosseum would allow you erroneously to build inside the areas i've marked in the screenshot below with pink quarter blocks. I've removed these as well.

![Screenshot_select-area_20240227163145](https://github.com/OpenRCT2/objects/assets/42477864/b50cc21d-6866-4c03-906f-6b456a2b8d95)
