### PR TITLE
Update names for WWTT flying saucers vehicles

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.cyclopsx.json
+++ b/objects/rct2tt/ride/rct2tt.ride.cyclopsx.json
@@ -53,7 +53,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Cyclops Ride",
+            "en-GB": "Cyclops Dodgems",
             "fr-FR": "Le cyclope",
             "de-DE": "Zyklopenfahrt",
             "es-ES": "Viaje del cíclope",

--- a/objects/rct2tt/ride/rct2tt.ride.flwrpowr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.flwrpowr.json
@@ -59,7 +59,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Flower Power Ride",
+            "en-GB": "Flower Power Dodgems",
             "fr-FR": "Flower Power",
             "de-DE": "Flower-Power-Fahrt",
             "es-ES": "Viaje de poder de las flores",

--- a/objects/rct2ww/ride/rct2ww.ride.dragdodg.json
+++ b/objects/rct2ww/ride/rct2ww.ride.dragdodg.json
@@ -53,7 +53,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Chinese Dragonhead Ride",
+            "en-GB": "Chinese Dragonhead Dodgems",
             "fr-FR": "La tête du dragon",
             "de-DE": "Chinesische Drachenkopffahrt",
             "es-ES": "Montaña Rusa Cabeza de Dragón Chino",


### PR DESCRIPTION
Updates the names for the WWTT flying saucers vehicles to refer to them as Dodgems like the skidoo dodgems, rather than separate rides.

I haven't touched the non en-GB strings, i'll make a PR to the localisation repo to add the en-US bumper car strings after this is pushed. For the rest it'd probably make sense to create an issue on the localisation repo to let translators know to update them?

Closes #309