### PR TITLE
Fix #296: wall placement around large Kremlin/drab pieces incorrect

### DIFF
--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab01.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab01.json
@@ -28,13 +28,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 64,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 64,
-                "walls": 2
+                "walls": 6
             }
         ]
     },

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab02.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab02.json
@@ -28,13 +28,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 64,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 64,
-                "walls": 2
+                "walls": 6
             }
         ]
     },

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab03.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab03.json
@@ -28,13 +28,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 96,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 96,
-                "walls": 2
+                "walls": 6
             }
         ]
     },

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab04.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rdrab04.json
@@ -28,13 +28,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 64,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 64,
-                "walls": 2
+                "walls": 6
             }
         ]
     },

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml08.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml08.json
@@ -28,13 +28,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 64,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 64,
-                "walls": 2
+                "walls": 6
             }
         ]
     },

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml09.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml09.json
@@ -30,13 +30,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 128,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 128,
-                "walls": 2
+                "walls": 6
             }
         ]
     },

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml10.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml10.json
@@ -28,13 +28,13 @@
                 "x": 32,
                 "y": 0,
                 "clearance": 64,
-                "walls": 8
+                "walls": 12
             },
             {
                 "x": 32,
                 "y": 32,
                 "clearance": 64,
-                "walls": 2
+                "walls": 6
             }
         ]
     },


### PR DESCRIPTION
Wall placement is done using four bits. In all cases, the edges represented by `4` (bit 2) were not properly set, so had to be added.