### PR TITLE
Fix mandarin duck boats capacity

### DIFF
--- a/objects/rct2ww/ride/rct2ww.ride.mandarin.json
+++ b/objects/rct2ww/ride/rct2ww.ride.mandarin.json
@@ -112,22 +112,22 @@
         },
         "capacity": {
             "en-GB": "2 passengers per boat",
-            "fr-FR": "4 passagers par bateau",
-            "de-DE": "4 Fahrgäste pro Boot",
-            "es-ES": "4 pasajeros por bote",
-            "it-IT": "4 passeggeri per imbarcazione",
-            "nl-NL": "4 passagiers per boot",
-            "sv-SE": "4 passagerare per båt",
-            "zh-CN": "4位乘客/船",
-            "ja-JP": "各ボート4名",
-            "cs-CZ": "4 místa na každé lodi",
-            "ko-KR": "보트당 4명의 승객",
-            "pl-PL": "4 pasażerów na łódkę",
-            "pt-BR": "4 passageiros por barco",
-            "ru-RU": "4 пассажира в лодке",
-            "eo-ZZ": "Po 4 pasaĝeroj por boato",
-            "ca-ES": "4 passatgers per barca",
-            "fi-FI": "4 matkustajaa per vene"
+            "fr-FR": "2 passagers par bateau",
+            "de-DE": "2 Fahrgäste pro Boot",
+            "es-ES": "2 pasajeros por bote",
+            "it-IT": "2 passeggeri per imbarcazione",
+            "nl-NL": "2 passagiers per boot",
+            "sv-SE": "2 passagerare per båt",
+            "zh-CN": "2位乘客/船",
+            "ja-JP": "各ボート2名",
+            "cs-CZ": "2 místa na každé lodi",
+            "ko-KR": "보트당 2명의 승객",
+            "pl-PL": "2 pasażerów na łódkę",
+            "pt-BR": "2 passageiros por barco",
+            "ru-RU": "2 пассажира в лодке",
+            "eo-ZZ": "Po 2 pasaĝeroj por boato",
+            "ca-ES": "2 passatgers per barca",
+            "fi-FI": "2 matkustajaa per vene"
         }
     }
 }

--- a/objects/rct2ww/ride/rct2ww.ride.mandarin.json
+++ b/objects/rct2ww/ride/rct2ww.ride.mandarin.json
@@ -44,8 +44,8 @@
             "rotationFrameMask": 15,
             "spacing": 278912,
             "mass": 350,
-            "numSeats": 4,
-            "animation": 2,
+            "numSeats": 2,
+            "animation": 5,
             "numSeatRows": 3,
             "poweredAcceleration": 8,
             "poweredMaxSpeed": 5,
@@ -67,7 +67,8 @@
         }
     },
     "images": [
-        "$RCT2:OBJDATA/MANDARIN.DAT[0..66]"
+        "$RCT2:OBJDATA/MANDARIN.DAT[0..34]",
+        "$RCT2:OBJDATA/MANDARIN.DAT[51..66]"
     ],
     "strings": {
         "name": {
@@ -110,7 +111,7 @@
             "fi-FI": "Sorsan muotoiset veneet, jotka liikkuvat eturivin kävijöiden polkemana"
         },
         "capacity": {
-            "en-GB": "4 passengers per boat",
+            "en-GB": "2 passengers per boat",
             "fr-FR": "4 passagers par bateau",
             "de-DE": "4 Fahrgäste pro Boot",
             "es-ES": "4 pasajeros por bote",

--- a/objects/rct2ww/ride/rct2ww.ride.mandarin.json
+++ b/objects/rct2ww/ride/rct2ww.ride.mandarin.json
@@ -46,7 +46,7 @@
             "mass": 350,
             "numSeats": 2,
             "animation": 5,
-            "numSeatRows": 3,
+            "numSeatRows": 1,
             "poweredAcceleration": 8,
             "poweredMaxSpeed": 5,
             "drawOrder": 5,


### PR DESCRIPTION
This vehicle erroneously has it's seats set to 4 when only 2 guests are visible on the boat at a time. Due to some weirdness with how the swan boats animation style (animation: 2) is handled i've switched them over to the water trikes animation (animation: 5) which lets us shave off some dummy blank images the original object had to include as a hacky workaround for the swans animation style always expecting 2 sets of guest sprites (+1 for the animation if you want to count that) in a strange order.

On old saves that still have the duck vehicles spawned, they will retain their old capacity of 4 so this doesn't affect old saves. However due to the change in animation style there's a chance that on the first initial tick the sprites will be glitched as i believe it's still technically using the swans animation style for the first tick which will result in the second animation frame using some images from outside of the object's images table. After the first tick it fixes itself as it switches to the trikes animation so it's not super noticeable but i felt like it was worth mentioning just incase.

For the capacity string i've only changed en-GB, not really sure if i should change the others as it'd probably be cleaner to change them on the localisation repo.