### PR TITLE
Fix clipping of classic standup trains on small banked turns

### DIFF
--- a/objects/rct1/ride/rct1.ride.stand_up_trains/object.json
+++ b/objects/rct1/ride/rct1.ride.stand_up_trains/object.json
@@ -30,7 +30,7 @@
             "numSeatRows": 2,
             "frictionSoundId": 2,
             "soundRange": 2,
-            "drawOrder": 7,
+            "drawOrder": 6,
             "spriteGroups": {
                 "slopeFlat":16,
                 "slopes12":4,


### PR DESCRIPTION
Fixes clipping issue on banked 2x2 turns. https://github.com/OpenRCT2/OpenRCT2/pull/21642#issuecomment-2014076375