### PR TITLE
Rename rct2.audio.base to rct2.audio.base.rct2

### DIFF
--- a/objects/rct2/audio/rct2.audio.base.rct2.json
+++ b/objects/rct2/audio/rct2.audio.base.rct2.json
@@ -1,5 +1,5 @@
 {
-    "id": "rct2.audio.base",
+    "id": "rct2.audio.base.rct2",
     "authors": [
         "Chris Sawyer",
         "Allister Brimble"


### PR DESCRIPTION
Ties in with https://github.com/OpenRCT2/OpenRCT2/pull/21654.