### PR TITLE
Assorted color preset fixes

### DIFF
--- a/objects/rct2/ride/rct2.ride.togst.json
+++ b/objects/rct2/ride/rct2.ride.togst.json
@@ -24,22 +24,22 @@
             [
                 [
                     "yellow",
-                    "bright_red",
-                    "black"
+                    "black",
+                    "bright_red"
                 ]
             ],
             [
                 [
                     "bright_red",
-                    "white",
-                    "black"
+                    "black",
+                    "white"
                 ]
             ],
             [
                 [
                     "light_blue",
-                    "yellow",
-                    "black"
+                    "black",
+                    "yellow"
                 ]
             ]
         ],

--- a/objects/rct2tt/ride/rct2tt.ride.dinoeggs.json
+++ b/objects/rct2tt/ride/rct2tt.ride.dinoeggs.json
@@ -16,7 +16,7 @@
             [
                 [
                     "moss_green",
-                    "yellow",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2tt/ride/rct2tt.ride.flalmace.json
+++ b/objects/rct2tt/ride/rct2tt.ride.flalmace.json
@@ -21,29 +21,8 @@
         "carColours": [
             [
                 [
-                    "light_blue",
-                    "yellow",
-                    "black"
-                ]
-            ],
-            [
-                [
-                    "dark_green",
-                    "yellow",
-                    "black"
-                ]
-            ],
-            [
-                [
-                    "bright_red",
-                    "white",
-                    "black"
-                ]
-            ],
-            [
-                [
                     "black",
-                    "bright_red",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
@@ -15,8 +15,8 @@
         "carColours": [
             [
                 [
-                    "moss_green",
-                    "yellow",
+                    "black",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2tt/ride/rct2tt.ride.mgr2.json
+++ b/objects/rct2tt/ride/rct2tt.ride.mgr2.json
@@ -21,9 +21,9 @@
         "carColours": [
             [
                 [
-                    "dark_blue",
-                    "light_pink",
-                    "yellow"
+                    "black",
+                    "bright_pink",
+                    "black"
                 ]
             ]
         ],

--- a/objects/rct2tt/ride/rct2tt.ride.mgr2.json
+++ b/objects/rct2tt/ride/rct2tt.ride.mgr2.json
@@ -23,7 +23,7 @@
                 [
                     "black",
                     "bright_pink",
-                    "black"
+                    "yellow"
                 ]
             ]
         ],

--- a/objects/rct2tt/ride/rct2tt.ride.neptunex.json
+++ b/objects/rct2tt/ride/rct2tt.ride.neptunex.json
@@ -15,8 +15,8 @@
         "carColours": [
             [
                 [
-                    "moss_green",
-                    "yellow",
+                    "black",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2tt/ride/rct2tt.ride.timemach.json
+++ b/objects/rct2tt/ride/rct2tt.ride.timemach.json
@@ -15,29 +15,8 @@
         "carColours": [
             [
                 [
-                    "light_blue",
-                    "yellow",
-                    "black"
-                ]
-            ],
-            [
-                [
-                    "dark_green",
-                    "yellow",
-                    "black"
-                ]
-            ],
-            [
-                [
-                    "bright_red",
-                    "white",
-                    "black"
-                ]
-            ],
-            [
-                [
                     "black",
-                    "bright_red",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2tt/ride/rct2tt.ride.tommygun.json
+++ b/objects/rct2tt/ride/rct2tt.ride.tommygun.json
@@ -15,8 +15,8 @@
         "carColours": [
             [
                 [
-                    "moss_green",
-                    "yellow",
+                    "black",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2ww/ride/rct2ww.ride.diamondr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.diamondr.json
@@ -15,8 +15,8 @@
         "carColours": [
             [
                 [
-                    "moss_green",
-                    "yellow",
+                    "black",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2ww/ride/rct2ww.ride.faberge.json
+++ b/objects/rct2ww/ride/rct2ww.ride.faberge.json
@@ -15,8 +15,8 @@
         "carColours": [
             [
                 [
-                    "moss_green",
-                    "yellow",
+                    "black",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2ww/ride/rct2ww.ride.firecrak.json
+++ b/objects/rct2ww/ride/rct2ww.ride.firecrak.json
@@ -16,22 +16,8 @@
         "carColours": [
             [
                 [
-                    "bright_red",
-                    "white",
-                    "black"
-                ]
-            ],
-            [
-                [
-                    "saturated_green",
-                    "bright_red",
-                    "black"
-                ]
-            ],
-            [
-                [
-                    "light_blue",
-                    "yellow",
+                    "black",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2ww/ride/rct2ww.ride.junkswng.json
+++ b/objects/rct2ww/ride/rct2ww.ride.junkswng.json
@@ -17,21 +17,21 @@
             [
                 [
                     "dark_brown",
-                    "yellow",
+                    "bright_pink",
                     "black"
                 ]
             ],
             [
                 [
                     "bordeaux_red",
-                    "white",
+                    "bright_pink",
                     "black"
                 ]
             ],
             [
                 [
                     "black",
-                    "bordeaux_red",
+                    "bright_pink",
                     "black"
                 ]
             ]

--- a/objects/rct2ww/ride/rct2ww.ride.ostrich.json
+++ b/objects/rct2ww/ride/rct2ww.ride.ostrich.json
@@ -22,21 +22,21 @@
                 [
                     "yellow",
                     "bright_red",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "bright_red",
                     "white",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "light_blue",
                     "yellow",
-                    "black"
+                    "yellow"
                 ]
             ]
         ],
@@ -62,7 +62,6 @@
                     "corkscrews": true,
                     "restraintAnimation": true
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [


### PR DESCRIPTION
Note that these changes will not affect old parks, only parks where these vehicles/rides have been newly spawned.

Firstly i've removed the third remap from the ostrich trains as it doesn't seem intended to be remappable as it uses colors from both the yellow (third remap) & brown palettes so i've removed the third remap flag and set the third colors of all it's presets to yellow.
Old
![image1](https://github.com/user-attachments/assets/3418b3fe-3041-422d-8129-e52041a2f6a6)
New
![image2](https://github.com/user-attachments/assets/04c52314-73c2-426e-8293-193456cf6a2a)


Secondly i've swapped the second & third colors in the presets of the RCT2 stand-up trains as this seems like an error as in RCT1 the second color corresponded to the restraints while in RCT2 the restraints use the third color. The presets for this vehicle were pretty clearly just taken over from RCT1 but second & third colors weren't swapped to account for the different color mapping. I've fixed this and here's how the presets look now:
![Freds_Workbench_2024-11-18_17-13-32](https://github.com/user-attachments/assets/47ea7ee4-ae19-4c3d-a2b4-77c31d379812)

And lastly i've applied what was done in the previous wave of color preset fixes to the WWTT flat rides where applicable, most of them don't use the third color at all due to how flats are rendered so i haven't changed that but i've changed all hidden second colors to bright pink as well as setting the primary color to black. Note that i preserved the first color on the dino eggs ride as it's actually an intended remap, the rest of them don't seem to support remapping however. I also got rid of some useless presets on rides which can't be remapped at all (eg: firecracker ride).

