### PR TITLE
Add RCT1AA source game to peep names.

### DIFF
--- a/objects/rct2/peep_names/rct2.peep_names.original.json
+++ b/objects/rct2/peep_names/rct2.peep_names.original.json
@@ -5,7 +5,8 @@
     ],
     "version": "1.0",
     "sourceGame": [
-        "rct2"
+        "rct2",
+        "rct1aa"
     ],
     "objectType": "peep_names",
     "strings": {


### PR DESCRIPTION
Noticed this was missing an RCT1 source game, going by the RCT wiki (https://rct.wiki/wiki/Added_Attractions) the real names option was introduced in Added Attractions, so i've marked it as such.