### PR TITLE
Use drawOrder 12 for 1920racr

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.1920racr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.1920racr.json
@@ -184,7 +184,7 @@
             "doubleSoundFrequency": 1,
             "poweredAcceleration": 35,
             "poweredMaxSpeed": 40,
-            "drawOrder": 7,
+            "drawOrder": 12,
             "frames": {
                 "flat": true,
                 "gentleSlopes": true


### PR DESCRIPTION
This fixes an issue where the bounding box doesn't encompass the whole sprite of the vehicle leading to visual glitches, from what i've tested a drawOrder of 12 seems to work the best for these vehicles. Portions of the sprites still poke out of the bounding box but it's not as bad as before.

This is primarily for https://github.com/OpenRCT2/OpenRCT2/pull/23626 but it also improves how the vehicles look on the vanilla pieces too.