### PR TITLE
Skidoo > Snowmobile renames

### DIFF
--- a/objects/rct2ww/ride/rct2ww.ride.skidoo.json
+++ b/objects/rct2ww/ride/rct2ww.ride.skidoo.json
@@ -53,8 +53,8 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Skidoo Dodgems",
-            "en-US": "Skidoo Bumper Cars",
+            "en-GB": "Snowmobile Dodgems",
+            "en-US": "Snowmobile Bumper Cars",
             "fr-FR": "Motoneiges-tamponneuses",
             "de-DE": "Schlitterscooter",
             "es-ES": "Coches de choque esquimales",
@@ -73,7 +73,7 @@
             "fi-FI": "Moottorikelkat"
         },
         "description": {
-            "en-GB": "Guests slide around in skidoo-shaped vehicles that they freely control",
+            "en-GB": "Guests slide around in snowmobile-shaped vehicles that they freely control",
             "fr-FR": "Les passagers glissent sur des véhicules en forme de motoneiges qu’ils contrôlent à leur guise",
             "de-DE": "Die Fahrgäste schlittern in selbstgesteuerten schlittenförmigen Fahrzeugen umher",
             "es-ES": "Coches de choque eléctricos de conducción propia",


### PR DESCRIPTION
The term skidoo seems to be trademarked and primarily applies to a specific brand of snowmobiles rather than being a generic term for them. (https://ski-doo.brp.com/us/en/legal-notice.html) And also this like it would violate the no advertising clause or whatever it was that got some of the easter eggs and the overt six flags branding removed.

So i feel like these strings should be changed just to be on the safe side.

I have also updated en-US here, if that would be better suited in the localisation repo i can remove it from here and update it there instead. Other language strings have not been updated and some of them do seem to refer to them as skidoo so those will need to be changed too.