### PR TITLE
Add new color presets to panda trains

### DIFF
--- a/objects/official/ride/rct2dlc.ride.zpanda/object.json
+++ b/objects/official/ride/rct2dlc.ride.zpanda/object.json
@@ -30,6 +30,21 @@
                     "black",
                     "white",
                     "black"
+                ],
+                [
+                    "umber",
+                    "white",
+                    "black"
+                ],
+                [
+                    "umber",
+                    "umber",
+                    "black"
+                ],
+                [
+                    "white",
+                    "white",
+                    "black"
                 ]
             ]
         ],


### PR DESCRIPTION
This adds these three new presets to the panda trains:

![panda3](https://github.com/user-attachments/assets/feb7076f-127d-4037-ab42-802dce481953)

Umber and white for brown panda, all umber for grizzly bear and all white for polar bear