### PR TITLE
Add RCT1 color-like presets to Mine Train RC

### DIFF
--- a/objects/rct2/ride/rct2.ride.amt1.json
+++ b/objects/rct2/ride/rct2.ride.amt1.json
@@ -31,6 +31,20 @@
                     "black",
                     "bordeaux_red"
                 ]
+            ],
+            [
+                [
+                    "saturated_brown",
+                    "light_brown",
+                    "black"
+                ]
+            ],
+            [
+                [
+                    "dark_green",
+                    "black",
+                    "light_brown"
+                ]
             ]
         ],
         "cars": [

--- a/objects/rct2/ride/rct2.ride.amt1.json
+++ b/objects/rct2/ride/rct2.ride.amt1.json
@@ -43,7 +43,7 @@
                 [
                     "dark_green",
                     "black",
-                    "light_brown"
+                    "black"
                 ]
             ]
         ],


### PR DESCRIPTION
Brown RCT1 color scheme for Mine Train Coaster:

![openrct_mine2](https://github.com/user-attachments/assets/af229b85-5732-4562-96ee-ad0eebbd16fa)

Not identical but similar to the RCT1 green color scheme for Mine Train Coaster:

![openrct_mine1](https://github.com/user-attachments/assets/f2f8fb03-89cb-4c94-ad56-7dc218f83b86)
