### PR TITLE
Add RCT1 color preset to Junior RC log trains

### DIFF
--- a/objects/rct2/ride/rct2.ride.zlog.json
+++ b/objects/rct2/ride/rct2.ride.zlog.json
@@ -38,6 +38,13 @@
                     "bordeaux_red",
                     "black"
                 ]
+            ],            
+            [
+                [
+                    "dark_brown",
+                    "dark_green",
+                    "black"
+                ]
             ]
         ],
         "cars": [


### PR DESCRIPTION
Adding RCT1 dark brown/green color scheme to Junior RC log trains

![openrct_junior](https://github.com/user-attachments/assets/21a32611-2536-49a1-b095-e839715c6ec8)
