### PR TITLE
Disable base colour on non-remappable WWTT vehicles, change black to light_blue

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.bmvoctps.json
+++ b/objects/rct2tt/ride/rct2tt.ride.bmvoctps.json
@@ -19,7 +19,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.bmvoctps.json
+++ b/objects/rct2tt/ride/rct2tt.ride.bmvoctps.json
@@ -26,6 +26,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "rotationFrameMask": 7,
             "spacing": 862884,
             "mass": 2500,

--- a/objects/rct2tt/ride/rct2tt.ride.bmvoctps.json
+++ b/objects/rct2tt/ride/rct2tt.ride.bmvoctps.json
@@ -26,7 +26,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "rotationFrameMask": 7,
             "spacing": 862884,
             "mass": 2500,

--- a/objects/rct2tt/ride/rct2tt.ride.flalmace.json
+++ b/objects/rct2tt/ride/rct2tt.ride.flalmace.json
@@ -28,6 +28,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "spacing": 139456,
             "mass": 1000,
             "numSeats": 1,

--- a/objects/rct2tt/ride/rct2tt.ride.flalmace.json
+++ b/objects/rct2tt/ride/rct2tt.ride.flalmace.json
@@ -28,7 +28,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 1000,
             "numSeats": 1,

--- a/objects/rct2tt/ride/rct2tt.ride.flalmace.json
+++ b/objects/rct2tt/ride/rct2tt.ride.flalmace.json
@@ -21,7 +21,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
@@ -22,7 +22,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.gintspdr.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.mgr2.json
+++ b/objects/rct2tt/ride/rct2tt.ride.mgr2.json
@@ -21,7 +21,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.mgr2.json
+++ b/objects/rct2tt/ride/rct2tt.ride.mgr2.json
@@ -28,6 +28,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 139456,
             "mass": 200,

--- a/objects/rct2tt/ride/rct2tt.ride.neptunex/object.json
+++ b/objects/rct2tt/ride/rct2tt.ride.neptunex/object.json
@@ -22,7 +22,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2tt/ride/rct2tt.ride.neptunex/object.json
+++ b/objects/rct2tt/ride/rct2tt.ride.neptunex/object.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2tt/ride/rct2tt.ride.neptunex/object.json
+++ b/objects/rct2tt/ride/rct2tt.ride.neptunex/object.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.raptorxx.json
+++ b/objects/rct2tt/ride/rct2tt.ride.raptorxx.json
@@ -16,7 +16,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.rivrstyx/object.json
+++ b/objects/rct2tt/ride/rct2tt.ride.rivrstyx/object.json
@@ -24,6 +24,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 313776,
             "mass": 950,

--- a/objects/rct2tt/ride/rct2tt.ride.rivrstyx/object.json
+++ b/objects/rct2tt/ride/rct2tt.ride.rivrstyx/object.json
@@ -17,7 +17,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.rivrstyx/object.json
+++ b/objects/rct2tt/ride/rct2tt.ride.rivrstyx/object.json
@@ -24,7 +24,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 313776,
             "mass": 950,

--- a/objects/rct2tt/ride/rct2tt.ride.telepter.json
+++ b/objects/rct2tt/ride/rct2tt.ride.telepter.json
@@ -17,7 +17,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.timemach.json
+++ b/objects/rct2tt/ride/rct2tt.ride.timemach.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 1000,
             "numSeats": 1,

--- a/objects/rct2tt/ride/rct2tt.ride.timemach.json
+++ b/objects/rct2tt/ride/rct2tt.ride.timemach.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.tommygun.json
+++ b/objects/rct2tt/ride/rct2tt.ride.tommygun.json
@@ -22,7 +22,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2tt/ride/rct2tt.ride.tommygun.json
+++ b/objects/rct2tt/ride/rct2tt.ride.tommygun.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2tt/ride/rct2tt.ride.tommygun.json
+++ b/objects/rct2tt/ride/rct2tt.ride.tommygun.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.trilobte.json
+++ b/objects/rct2tt/ride/rct2tt.ride.trilobte.json
@@ -23,7 +23,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2tt/ride/rct2tt.ride.trilobte.json
+++ b/objects/rct2tt/ride/rct2tt.ride.trilobte.json
@@ -61,7 +61,7 @@
                 ]
             },
             {
-		        "hasBaseColour": false,
+                "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,

--- a/objects/rct2tt/ride/rct2tt.ride.trilobte.json
+++ b/objects/rct2tt/ride/rct2tt.ride.trilobte.json
@@ -31,6 +31,7 @@
         ],
         "cars": [
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 313776,
                 "mass": 950,
@@ -60,6 +61,7 @@
                 ]
             },
             {
+		        "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,

--- a/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
+++ b/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 174320,
             "mass": 2000,

--- a/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
+++ b/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
@@ -22,7 +22,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 174320,
             "mass": 2000,

--- a/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
+++ b/objects/rct2tt/ride/rct2tt.ride.valkyrie.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.blackcab.json
+++ b/objects/rct2ww/ride/rct2ww.ride.blackcab.json
@@ -29,6 +29,7 @@
         ],
         "cars": [
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 174320,
                 "mass": 300,
@@ -48,6 +49,7 @@
                 ]
             },
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,

--- a/objects/rct2ww/ride/rct2ww.ride.blackcab.json
+++ b/objects/rct2ww/ride/rct2ww.ride.blackcab.json
@@ -21,7 +21,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.dhowwatr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.dhowwatr.json
@@ -24,6 +24,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "rotationFrameMask": 15,
             "spacing": 278912,
             "mass": 180,

--- a/objects/rct2ww/ride/rct2ww.ride.dhowwatr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.dhowwatr.json
@@ -17,7 +17,7 @@
         "carColours": [
             [
                 [
-                    "saturated_brown",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.diamondr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.diamondr.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2ww/ride/rct2ww.ride.diamondr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.diamondr.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.faberge.json
+++ b/objects/rct2ww/ride/rct2ww.ride.faberge.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -12,

--- a/objects/rct2ww/ride/rct2ww.ride.faberge.json
+++ b/objects/rct2ww/ride/rct2ww.ride.faberge.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.firecrak.json
+++ b/objects/rct2ww/ride/rct2ww.ride.firecrak.json
@@ -23,7 +23,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -24,

--- a/objects/rct2ww/ride/rct2ww.ride.firecrak.json
+++ b/objects/rct2ww/ride/rct2ww.ride.firecrak.json
@@ -16,7 +16,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "black"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.firecrak.json
+++ b/objects/rct2ww/ride/rct2ww.ride.firecrak.json
@@ -23,6 +23,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "spacing": 139456,
             "mass": 200,
             "tabOffset": -24,

--- a/objects/rct2ww/ride/rct2ww.ride.hipporid.json
+++ b/objects/rct2ww/ride/rct2ww.ride.hipporid.json
@@ -25,6 +25,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 278912,
             "mass": 300,

--- a/objects/rct2ww/ride/rct2ww.ride.huskie.json
+++ b/objects/rct2ww/ride/rct2ww.ride.huskie.json
@@ -50,7 +50,7 @@
                 ]
             },
             {
-		        "hasBaseColour": false,
+                "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 60,

--- a/objects/rct2ww/ride/rct2ww.ride.huskie.json
+++ b/objects/rct2ww/ride/rct2ww.ride.huskie.json
@@ -28,6 +28,7 @@
         ],
         "cars": [
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 244048,
                 "mass": 3000,
@@ -49,6 +50,7 @@
                 ]
             },
             {
+		        "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 60,

--- a/objects/rct2ww/ride/rct2ww.ride.huskie.json
+++ b/objects/rct2ww/ride/rct2ww.ride.huskie.json
@@ -20,21 +20,7 @@
         "carColours": [
             [
                 [
-                    "bordeaux_red",
-                    "bright_pink",
-                    "yellow"
-                ]
-            ],
-            [
-                [
-                    "yellow",
-                    "bright_pink",
-                    "yellow"
-                ]
-            ],
-            [
-                [
-                    "dark_blue",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.lionride.json
+++ b/objects/rct2ww/ride/rct2ww.ride.lionride.json
@@ -20,6 +20,7 @@
             ]
         ],
         "cars": {
+		    "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 235332,
             "mass": 790,

--- a/objects/rct2ww/ride/rct2ww.ride.lionride.json
+++ b/objects/rct2ww/ride/rct2ww.ride.lionride.json
@@ -20,7 +20,7 @@
             ]
         ],
         "cars": {
-		    "hasBaseColour": false,
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 235332,
             "mass": 790,

--- a/objects/rct2ww/ride/rct2ww.ride.lionride.json
+++ b/objects/rct2ww/ride/rct2ww.ride.lionride.json
@@ -13,7 +13,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.londonbs.json
+++ b/objects/rct2ww/ride/rct2ww.ride.londonbs.json
@@ -29,7 +29,7 @@
         ],
         "cars": [
             {
-		        "hasBaseColour": false,
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 3000,
@@ -60,7 +60,7 @@
                 ]
             },
             {
-		        "hasBaseColour": false,
+                "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 139456,
                 "frictionSoundId": 31,

--- a/objects/rct2ww/ride/rct2ww.ride.londonbs.json
+++ b/objects/rct2ww/ride/rct2ww.ride.londonbs.json
@@ -21,7 +21,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.londonbs.json
+++ b/objects/rct2ww/ride/rct2ww.ride.londonbs.json
@@ -29,6 +29,7 @@
         ],
         "cars": [
             {
+		        "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 3000,
@@ -59,6 +60,7 @@
                 ]
             },
             {
+		        "hasBaseColour": false,
                 "rotationFrameMask": 0,
                 "spacing": 139456,
                 "frictionSoundId": 31,

--- a/objects/rct2ww/ride/rct2ww.ride.minecart.json
+++ b/objects/rct2ww/ride/rct2ww.ride.minecart.json
@@ -15,7 +15,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.minecart.json
+++ b/objects/rct2ww/ride/rct2ww.ride.minecart.json
@@ -22,6 +22,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 209184,
             "mass": 540,

--- a/objects/rct2ww/ride/rct2ww.ride.minelift.json
+++ b/objects/rct2ww/ride/rct2ww.ride.minelift.json
@@ -17,7 +17,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.polarber.json
+++ b/objects/rct2ww/ride/rct2ww.ride.polarber.json
@@ -21,7 +21,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.polarber.json
+++ b/objects/rct2ww/ride/rct2ww.ride.polarber.json
@@ -28,6 +28,7 @@
             ]
         ],
         "cars": {
+            "hasBaseColour": false,
             "rotationFrameMask": 31,
             "spacing": 200468,
             "mass": 580,

--- a/objects/rct2ww/ride/rct2ww.ride.taxicstr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.taxicstr.json
@@ -21,7 +21,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.taxicstr.json
+++ b/objects/rct2ww/ride/rct2ww.ride.taxicstr.json
@@ -29,6 +29,7 @@
         ],
         "cars": [
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 244048,
                 "mass": 600,
@@ -58,6 +59,7 @@
                 ]
             },
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 226616,
                 "mass": 500,
@@ -87,6 +89,7 @@
                 ]
             },
             {
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 52296,
                 "mass": 50,

--- a/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
+++ b/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
@@ -14,7 +14,7 @@
         "carColours": [
             [
                 [
-                    "black",
+                    "light_blue",
                     "bright_pink",
                     "yellow"
                 ]

--- a/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
+++ b/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
@@ -22,6 +22,7 @@
         ],
         "cars": [
             {
+		        "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 950,
@@ -50,6 +51,7 @@
                 ]
             },
             {
+		        "hasBaseColour": false
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 950,

--- a/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
+++ b/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
@@ -51,7 +51,7 @@
                 ]
             },
             {
-                "hasBaseColour": false
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 950,

--- a/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
+++ b/objects/rct2ww/ride/rct2ww.ride.tigrtwst/object.json
@@ -22,7 +22,7 @@
         ],
         "cars": [
             {
-		        "hasBaseColour": false,
+                "hasBaseColour": false,
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 950,
@@ -51,7 +51,7 @@
                 ]
             },
             {
-		        "hasBaseColour": false
+                "hasBaseColour": false
                 "rotationFrameMask": 31,
                 "spacing": 278912,
                 "mass": 950,


### PR DESCRIPTION
Disables the base colour on all non-remappable WWTT vehicles, i've also change all instances of black in their color presets to light_blue as primary remap seems to have been an off blue color going by the evo of RCT so this is more accurate. This fix was already used for the hippo submarines so this just applies it to all objects.

I also properly disabled remaps on the dhow boats & huskie vehicles as i had missed them during the previous WWTT preset fixes.