### PR TITLE
Remove erroneously enabled WWTT third remaps

### DIFF
--- a/objects/rct2tt/ride/rct2tt.ride.barnstrm.json
+++ b/objects/rct2tt/ride/rct2tt.ride.barnstrm.json
@@ -18,7 +18,7 @@
                 [
                     "light_blue",
                     "black",
-                    "bright_red"
+                    "yellow"
                 ]
             ],
             [
@@ -32,7 +32,7 @@
                 [
                     "bordeaux_red",
                     "white",
-                    "black"
+                    "yellow"
                 ]
             ]
         ],
@@ -53,7 +53,6 @@
                 "verticalSlopes": true,
                 "restraintAnimation": true
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasScreamingRiders": true,
             "loadingPositions": [

--- a/objects/rct2tt/ride/rct2tt.ride.battrram.json
+++ b/objects/rct2tt/ride/rct2tt.ride.battrram.json
@@ -16,14 +16,14 @@
                 [
                     "black",
                     "yellow",
-                    "bordeaux_red"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "saturated_red",
                     "bright_red",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
@@ -56,7 +56,6 @@
                 "flatToGentleSlopeWhileBankedTransitions": true,
                 "curvedLiftHill": true
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasScreamingRiders": true,
             "loadingPositions": [

--- a/objects/rct2tt/ride/rct2tt.ride.dragnfly.json
+++ b/objects/rct2tt/ride/rct2tt.ride.dragnfly.json
@@ -15,21 +15,21 @@
                 [
                     "black",
                     "light_orange",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "bright_red",
                     "yellow",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "dark_green",
                     "bright_red",
-                    "black"
+                    "yellow"
                 ]
             ]
         ],

--- a/objects/rct2tt/ride/rct2tt.ride.dragnfly.json
+++ b/objects/rct2tt/ride/rct2tt.ride.dragnfly.json
@@ -50,7 +50,6 @@
                 "slopes8": 4,
                 "slopes16": 4
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasSwinging": true,
             "hasScreamingRiders": true,

--- a/objects/rct2tt/ride/rct2tt.ride.jetpackx.json
+++ b/objects/rct2tt/ride/rct2tt.ride.jetpackx.json
@@ -17,14 +17,14 @@
                 [
                     "bright_red",
                     "grey",
-                    "light_purple"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "yellow",
                     "bordeaux_red",
-                    "bordeaux_red"
+                    "yellow"
                 ]
             ],
             [
@@ -51,7 +51,6 @@
                 "verticalSlopes": true,
                 "restraintAnimation": true
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasScreamingRiders": true,
             "loadingPositions": [

--- a/objects/rct2tt/ride/rct2tt.ride.pterodac.json
+++ b/objects/rct2tt/ride/rct2tt.ride.pterodac.json
@@ -18,14 +18,14 @@
                 [
                     "bright_red",
                     "yellow",
-                    "dark_purple"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "teal",
                     "grey",
-                    "black"
+                    "yellow"
                 ]
             ]
         ],
@@ -55,7 +55,6 @@
                     "restraintAnimation": true
                 },
                 "hasInvertedSpriteSet": true,
-                "hasAdditionalColour2": true,
                 "spriteBoundsIncludeInvertedSet": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
@@ -91,7 +90,6 @@
                     "restraintAnimation": true
                 },
                 "hasInvertedSpriteSet": true,
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [

--- a/objects/rct2ww/ride/rct2ww.ride.bomerang.json
+++ b/objects/rct2ww/ride/rct2ww.ride.bomerang.json
@@ -21,21 +21,21 @@
                 [
                     "bright_red",
                     "bright_yellow",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "light_blue",
                     "bright_red",
-                    "black"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "yellow",
                     "bright_red",
-                    "black"
+                    "yellow"
                 ]
             ]
         ],
@@ -57,7 +57,6 @@
                     "flatBanked": true,
                     "restraintAnimation": true
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [
@@ -79,7 +78,6 @@
                     "verticalSlopes": true,
                     "flatBanked": true
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
             }

--- a/objects/rct2ww/ride/rct2ww.ride.congaeel.json
+++ b/objects/rct2ww/ride/rct2ww.ride.congaeel.json
@@ -39,7 +39,7 @@
                 [
                     "white",
                     "bordeaux_red",
-                    "bordeaux_red"
+                    "yellow"
                 ]
             ]
         ],
@@ -65,7 +65,6 @@
                     "corkscrews": true,
                     "restraintAnimation": true
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [
@@ -96,7 +95,6 @@
                     "corkscrews": true,
                     "restraintAnimation": true
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [

--- a/objects/rct2ww/ride/rct2ww.ride.football.json
+++ b/objects/rct2ww/ride/rct2ww.ride.football.json
@@ -23,14 +23,14 @@
                 [
                     "dark_green",
                     "dark_purple",
-                    "white"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "white",
                     "grey",
-                    "bright_red"
+                    "yellow"
                 ]
             ]
         ],
@@ -51,7 +51,6 @@
                 "diagonalSlopes": true,
                 "restraintAnimation": true
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasSwinging": true,
             "hasScreamingRiders": true,

--- a/objects/rct2ww/ride/rct2ww.ride.rocket.json
+++ b/objects/rct2ww/ride/rct2ww.ride.rocket.json
@@ -24,14 +24,14 @@
                 [
                     "dark_green",
                     "dark_purple",
-                    "white"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "white",
                     "grey",
-                    "bright_red"
+                    "yellow"
                 ]
             ]
         ],
@@ -52,7 +52,6 @@
                 "diagonalSlopes": true,
                 "restraintAnimation": true
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasSwinging": true,
             "hasScreamingRiders": true,

--- a/objects/rct2ww/ride/rct2ww.ride.sloth.json
+++ b/objects/rct2ww/ride/rct2ww.ride.sloth.json
@@ -23,14 +23,14 @@
                 [
                     "dark_green",
                     "dark_purple",
-                    "white"
+                    "yellow"
                 ]
             ],
             [
                 [
                     "white",
                     "grey",
-                    "bright_red"
+                    "yellow"
                 ]
             ]
         ],
@@ -51,7 +51,6 @@
                 "diagonalSlopes": true,
                 "restraintAnimation": true
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasSwinging": true,
             "hasScreamingRiders": true,


### PR DESCRIPTION
Removes erroneously enabled third remaps on various WWTT vehicles that were not intended to be remappable, this can be seen blatantly on the barnstorming trains and battering ram trains while more subtly on the conger eel & various suspended swinging trains. (Restraints on these are a mix of brown & yellow pixels, suggesting it wasn't intended to be remappable.)

Fixes #370