### PR TITLE
Remove "hasAdditionalColour2" from wmmine

### DIFF
--- a/objects/rct2/ride/rct2.ride.wmmine.json
+++ b/objects/rct2/ride/rct2.ride.wmmine.json
@@ -61,7 +61,6 @@
                     "gentleSlopes": true,
                     "steepSlopes": true
                 },
-                "hasAdditionalColour2": true,
                 "hasSwinging": true,
                 "hasScreamingRiders": true,
                 "useWoodenWildMouseSwing": true,


### PR DESCRIPTION
The third color on the wooden wild mine cars is enabled by one of the vehicles which was hidden in the past as the game would originally only show the third remap if the second remap was enabled, but due to some recent refactors this now manifested in-game like so:
<img width="1920" height="1080" alt="ksnip_20250824-205140 webp" src="https://github.com/user-attachments/assets/6f55d808-1c08-472b-876d-302c1ac132af" />
So this fixes that. It only affects the RCT2 version as i guess i removed the additionalcolour2 flag from the RCT1 mine cars back in the day when i initially ported them.

I checked all the vehicles with this flag and there doesn't seem to be any other vehicles that are affected by this.

<img width="1920" height="1080" alt="ksnip_20250824-211157 webp" src="https://github.com/user-attachments/assets/937adbad-07d6-485b-b556-9be375783e0b" />

