### PR TITLE
Fix aussie fountain set name dupe

### DIFF
--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.fountrow.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.fountrow.json
@@ -46,24 +46,24 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Australian Fountain Set 2",
-            "fr-FR": "Fontaine australienne 2",
-            "de-DE": "Australisches Brunnen-Set 2",
-            "es-ES": "Conjunto fuente australiana 2",
-            "it-IT": "Fontane australiane, gruppo 2",
-            "nl-NL": "Stuk Australische fontein 2",
-            "sv-SE": "Australiensisk fontän 2",
+            "en-GB": "Australian Fountain Set 1",
+            "fr-FR": "Fontaine australienne 1",
+            "de-DE": "Australisches Brunnen-Set 1",
+            "es-ES": "Conjunto fuente australiana 1",
+            "it-IT": "Fontane australiane, gruppo 1",
+            "nl-NL": "Stuk Australische fontein 1",
+            "sv-SE": "Australiensisk fontän 1",
             "cs-CZ": "Australská fontána",
-            "ko-KR": "오스트레일리아 분수 세트 2",
-            "pl-PL": "Australijska fontanna zestaw 2",
-            "ru-RU": "Набор австралийских фонтанов 2",
-            "pt-BR": "Conjunto de Fontes Australianas 2",
-            "ja-JP": "オーストラリアの噴水セット２",
-            "eo-ZZ": "Aŭstralazia Fontanaro 2",
-            "ca-ES": "Conjunt de fonts australianes 2",
-            "fi-FI": "Australialainen suihkulähdesetti 2",
-            "zh-CN": "澳大利亚喷泉2",
-            "gl-ES": "Conxunto de Fontes Australianas 2"
+            "ko-KR": "오스트레일리아 분수 세트 1",
+            "pl-PL": "Australijska fontanna zestaw 1",
+            "ru-RU": "Набор австралийских фонтанов 1",
+            "pt-BR": "Conjunto de Fontes Australianas 1",
+            "ja-JP": "オーストラリアの噴水セット1",
+            "eo-ZZ": "Aŭstralazia Fontanaro 1",
+            "ca-ES": "Conjunt de fonts australianes 1",
+            "fi-FI": "Australialainen suihkulähdesetti 1",
+            "zh-CN": "澳大利亚喷泉1",
+            "gl-ES": "Conxunto de Fontes Australianas 1"
         }
     }
 }


### PR DESCRIPTION
The australian fountain set objects are both called "Australian Fountain Set 2", i've fixed this so that the 'rows' fountain set is now called "Australian Fountain Set 1" since it is the first one listed of the two in the australian theming. I have also applied this to all translations as we've done before for other numerical name changes like this (I hope i got the special numerical characters for jp-JP and zh-CN right? These were different from the other languages). cs-CZ is unchanged since there's no number there.
<img width="1920" height="1080" alt="ksnip_20250909-211249 webp" src="https://github.com/user-attachments/assets/aaeb8b96-382e-4ce6-9d0d-76e04470e581" />
