### PR TITLE
Remove 10% intensity modifier from LIM trains

### DIFF
--- a/objects/rct2/ride/rct2.ride.premt1.json
+++ b/objects/rct2/ride/rct2.ride.premt1.json
@@ -16,9 +16,6 @@
         "maxCarsPerTrain": 7,
         "defaultCar": 1,
         "headCars": 0,
-        "ratingMultipler": {
-            "intensity": 10
-        },
         "carColours": [
             [
                 [

--- a/objects/rct2tt/ride/rct2tt.ride.ganstrcr.json
+++ b/objects/rct2tt/ride/rct2tt.ride.ganstrcr.json
@@ -15,9 +15,6 @@
         "maxCarsPerTrain": 7,
         "defaultCar": 1,
         "headCars": 0,
-        "ratingMultipler": {
-            "intensity": 10
-        },
         "carColours": [
             [
                 [

--- a/objects/rct2ww/ride/rct2ww.ride.tgvtrain.json
+++ b/objects/rct2ww/ride/rct2ww.ride.tgvtrain.json
@@ -17,9 +17,6 @@
         "defaultCar": 1,
         "headCars": 0,
         "tailCars": 2,
-        "ratingMultipler": {
-            "intensity": 10
-        },
         "carColours": [
             [
                 [


### PR DESCRIPTION
After some discussion in the discord, i have come to the conclusion that the 10% intensity modifier the LIM trains have is an error that was unintentionally leftover when they were being cloned from the corkscrew trains, as there are other things about them that are the same as the corkscrew trains too. (vehicle color presets, vehicle masses)

As it just simply does not make sense for these trains to have an intensity modifier, they are the only trains for their ride type and said ride type already has it's own unique rating calculations that give it a lot of intensity already. This modifier seems like either an entirely erroneous leftover from the corkscrew coaster trains or a leftover from earlier development that was accidentally left in as this ride type was clearly rushed due to all the errors and oddities we've found with it over the years.

As such, this modifier should be removed. I've tested a few different designs with the modifier removed and building some new designs and it feels a lot better to build with now. Eg: You can actually build the big spaghetti bowl style designs this ride type does IRL without getting something like 11 intensity.

(This PR removes it from the gangster car & TGV train reskins as well in addition to the original train)