### PR TITLE
Fix penguin trains slopes12 error

### DIFF
--- a/objects/rct2ww/ride/rct2ww.ride.penguinb.json
+++ b/objects/rct2ww/ride/rct2ww.ride.penguinb.json
@@ -59,7 +59,11 @@
         }
     },
     "images": [
-        "$RCT2:OBJDATA/PENGUINB.DAT[0..2706]"
+        "$RCT2:OBJDATA/PENGUINB.DAT[0..509]",
+        "$RCT2:OBJDATA/PENGUINB.DAT[1251..1263]",
+        "$RCT2:OBJDATA/PENGUINB.DAT[523..1861]",
+        "$RCT2:OBJDATA/PENGUINB.DAT[2603..2615]",
+        "$RCT2:OBJDATA/PENGUINB.DAT[1875..2706]"
     ],
     "strings": {
         "name": {


### PR DESCRIPTION
Fixes the vehicle slopes12 down NW angle facing the wrong direction by referencing slopes25 sprites for this angle instead, the original slopes12 down NW sprites seem to be lost as i didn't see them anywhere in the images table for this object.

Unusually, the guest sprites were rendered correctly for the slopes12 down NW angle. I've still replaced them as it does look pretty strange having the guests change sprites while the vehicle stays static.

Before:
![ksnip_20251017-064501](https://github.com/user-attachments/assets/c85c41dc-17af-444d-a4dd-45683b2d5cf6)
![ksnip_20251017-064502](https://github.com/user-attachments/assets/7809f215-d426-4c4f-8cb5-cbeb9a6d4602)

After:
![ksnip_20251017-064540](https://github.com/user-attachments/assets/fadb9665-4cb5-4f0b-9fc9-ea399333b267)
![ksnip_20251017-064617](https://github.com/user-attachments/assets/3a3692f6-60df-42fc-8d37-43da6a38b73d)
