### PR TITLE
Add extra shop color presets

### DIFF
--- a/objects/rct2/ride/rct2.ride.balln.json
+++ b/objects/rct2/ride/rct2.ride.balln.json
@@ -24,6 +24,13 @@
                     "black",
                     "black"
                 ]
+            ],
+            [
+                [
+                    "bright_red",
+                    "black",
+                    "black"
+                ]
             ]
         ]
     },

--- a/objects/rct2/ride/rct2.ride.hatst.json
+++ b/objects/rct2/ride/rct2.ride.hatst.json
@@ -24,6 +24,20 @@
                     "black",
                     "black"
                 ]
+            ],
+            [
+                [
+                    "yellow",
+                    "black",
+                    "black"
+                ]
+            ],
+            [
+                [
+                    "grey",
+                    "black",
+                    "black"
+                ]
             ]
         ]
     },

--- a/objects/rct2/ride/rct2.ride.tshrt.json
+++ b/objects/rct2/ride/rct2.ride.tshrt.json
@@ -24,6 +24,27 @@
                     "black",
                     "black"
                 ]
+            ],
+            [
+                [
+                    "bright_purple",
+                    "black",
+                    "black"
+                ]
+            ],
+            [
+                [
+                    "bright_pink",
+                    "black",
+                    "black"
+                ]
+            ],
+            [
+                [
+                    "light_orange",
+                    "black",
+                    "black"
+                ]
             ]
         ]
     },


### PR DESCRIPTION
Adds new color presets to the hat stall & t-shirt stall from RCT1, as well as reintroducing the original bright red balloon stall color preset from vanilla RCT2 that we replaced years ago with the bright blue preset.

Will require https://github.com/OpenRCT2/OpenRCT2/pull/25453 to work properly.

![ksnip_20251110-180910](https://github.com/user-attachments/assets/d575794c-50ec-476e-9430-f44fa182a639)
