### PR TITLE
Fix alignment of rct2 red, yellow and green queue previews

### DIFF
--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_green/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_green/object.json
@@ -12,7 +12,7 @@
         "noSlopeRailings": true
     },
     "images": [
-        { "path": "preview.png" },
+        { "path": "preview.png", "x": 1, "y": 1 },
         "$RCT2:OBJDATA/TARMACG.DAT[51..70]"
     ],
     "strings": {

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_red/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_red/object.json
@@ -12,7 +12,7 @@
         "noSlopeRailings": true
     },
     "images": [
-        { "path": "preview.png" },
+        { "path": "preview.png", "x": 1, "y": 1 },
         "$RCT2:OBJDATA/PATHSPCE.DAT[51..70]"
     ],
     "strings": {

--- a/objects/rct2/footpath_surface/rct2.footpath_surface.queue_yellow/object.json
+++ b/objects/rct2/footpath_surface/rct2.footpath_surface.queue_yellow/object.json
@@ -12,7 +12,7 @@
         "noSlopeRailings": true
     },
     "images": [
-        { "path": "preview.png" },
+        { "path": "preview.png", "x": 1, "y": 1 },
         "$RCT2:OBJDATA/PATHASH.DAT[51..70]"
     ],
     "strings": {


### PR DESCRIPTION
Sets x and y offset for these previews to 1.
The other path previews have it already, eg:
https://github.com/OpenRCT2/objects/blob/405f733addb4476d36aac5edb2e660ec72a44e61/objects/rct2/footpath_surface/rct2.footpath_surface.crazy_paving/object.json#L11

<img width="569" height="635" alt="queuepreviewbug" src="https://github.com/user-attachments/assets/fdd21456-91ce-495a-bb38-80a270f6ddfe" />
