### PR TITLE
Add noReverseOption to RCT1 rev freefall

### DIFF
--- a/objects/rct1/ride/rct1.ride.reverse_freefall_car/object.json
+++ b/objects/rct1/ride/rct1.ride.reverse_freefall_car/object.json
@@ -14,6 +14,7 @@
         "category": "rollercoaster",
         "tabScale": 0.5,
         "carsPerFlatRide": 1,
+        "noReverseOption": true,
         "carColours": [
             [
                 [


### PR DESCRIPTION
These cars can't be reversed properly as they lack proper downwards slope sprites, so the option to reverse them shouldn't be available.

This is how they look when reversed for reference:
![ksnip_20260311-111216](https://github.com/user-attachments/assets/d0bb7297-c067-4fdf-8d0b-3cf89c64cdc6)
