### PR TITLE
Add limitAirTimeBonus to spinning cars

### DIFF
--- a/objects/rct1/ride/rct1.ride.spinning_cars/object.json
+++ b/objects/rct1/ride/rct1.ride.spinning_cars/object.json
@@ -11,6 +11,7 @@
     "properties": {
         "type": "classic_mini_rc",
         "category": "rollercoaster",
+        "limitAirTimeBonus": true,
         "maxCarsPerTrain": 4,
         "ratingMultipler": {
             "excitement": 5,


### PR DESCRIPTION
This flag is usually used on rides with over the shoulder restraints, so the spinning cars should have them too as they have over the shoulder restraints. I forgot to add this back when I did the majority of the metadata for this object as it just flew under the radar.