### PR TITLE
Add missing originalIds to scenery objects

### DIFF
--- a/objects/official/scenery_small/official.scenery_small.support_structure_half/object.json
+++ b/objects/official/scenery_small/official.scenery_small.support_structure_half/object.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000031|#SUPSS00|00000000",
     "sourceGame": "official",
     "objectType": "scenery_small",
     "properties": {

--- a/objects/official/scenery_small/toontowner.scenery_small.xxbbbr01_fix/object.json
+++ b/objects/official/scenery_small/toontowner.scenery_small.xxbbbr01_fix/object.json
@@ -5,6 +5,7 @@
         "ToonTowner"
     ],
     "version": "1.0",
+    "originalId": "00000031|#BRKBLOK|00000000",
     "sourceGame": "official",
     "objectType": "scenery_small",
     "properties": {

--- a/objects/official/scenery_wall/official.scenery_wall.post_flipped.json
+++ b/objects/official/scenery_wall/official.scenery_wall.post_flipped.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000033|#POSTFLP|00000000",
     "sourceGame": "official",
     "objectType": "scenery_wall",
     "properties": {

--- a/objects/official/scenery_wall/official.scenery_wall.support_structure_full/object.json
+++ b/objects/official/scenery_wall/official.scenery_wall.support_structure_full/object.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000033|#SUPWL00|00000000",
     "sourceGame": "official",
     "objectType": "scenery_wall",
     "properties": {

--- a/objects/official/scenery_wall/official.scenery_wall.support_structure_half/object.json
+++ b/objects/official/scenery_wall/official.scenery_wall.support_structure_half/object.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000053|#SUPWL01|00000000",
     "sourceGame": "official",
     "objectType": "scenery_wall",
     "properties": {

--- a/objects/official/scenery_wall/official.scenery_wall.support_structure_half/object.json
+++ b/objects/official/scenery_wall/official.scenery_wall.support_structure_half/object.json
@@ -5,7 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
-    "originalId": "00000053|#SUPWL01|00000000",
+    "originalId": "00000033|#SUPWL01|00000000",
     "sourceGame": "official",
     "objectType": "scenery_wall",
     "properties": {

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.playing_card_wall_1.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.playing_card_wall_1.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000043|#RCT1W00|00000000",
     "sourceGame": [
         "rct1"
     ],

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.playing_card_wall_2.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.playing_card_wall_2.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000043|#RCT1W01|00000000",
     "sourceGame": [
         "rct1"
     ],

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.roman_column_wall.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.roman_column_wall.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000043|#RCT1W02|00000000",
     "sourceGame": "rct1",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown.json
@@ -5,7 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
-    "originalId": "00000043|#RCT1W04|00000000",
+    "originalId": "00000043|#RCT1W03|00000000",
     "sourceGame": "rct1",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000043|#RCT1W04|00000000",
     "sourceGame": "rct1",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown_gate.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown_gate.json
@@ -5,7 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
-    "originalId": "00000043|#RCT1W03|00000000",
+    "originalId": "00000043|#RCT1W04|00000000",
     "sourceGame": "rct1",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown_gate.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_brown_gate.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000043|#RCT1W03|00000000",
     "sourceGame": "rct1",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_white.json
+++ b/objects/rct1/scenery_wall/rct1.scenery_wall.wooden_fence_white.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000043|#RCT1W05|00000000",
     "sourceGame": "rct1",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1aa.scenery_wall.glass_wall/object.json
+++ b/objects/rct1/scenery_wall/rct1aa.scenery_wall.glass_wall/object.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000053|#RCT1W06|00000000",
     "sourceGame": "rct1aa",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1aa.scenery_wall.wooden_post_wall_1.json
+++ b/objects/rct1/scenery_wall/rct1aa.scenery_wall.wooden_post_wall_1.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000053|#RCT1W07|00000000",
     "sourceGame": "rct1aa",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1aa.scenery_wall.wooden_post_wall_2.json
+++ b/objects/rct1/scenery_wall/rct1aa.scenery_wall.wooden_post_wall_2.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000053|#RCT1W08|00000000",
     "sourceGame": "rct1aa",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct1/scenery_wall/rct1ll.scenery_wall.medieval_wooden_fence.json
+++ b/objects/rct1/scenery_wall/rct1ll.scenery_wall.medieval_wooden_fence.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000063|#RCT1W09|00000000",
     "sourceGame": [
         "rct1ll"
     ],

--- a/objects/rct1/scenery_wall/rct1ll.scenery_wall.wooden_fence_brown_snow.json
+++ b/objects/rct1/scenery_wall/rct1ll.scenery_wall.wooden_fence_brown_snow.json
@@ -5,6 +5,7 @@
         "Simon Foster"
     ],
     "version": "1.0",
+    "originalId": "00000063|#RCT1W10|00000000",
     "sourceGame": "rct1ll",
     "isCompatibilityObject": true,
     "objectType": "scenery_wall",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.damtower_fix.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.damtower_fix.json
@@ -4,6 +4,7 @@
         "Frontier Studios"
     ],
     "version": "1.0",
+    "originalId": "00000012|#WWDAMTF|00000000",
     "sourceGame": "rct2ww",
     "objectType": "scenery_large",
     "properties": {


### PR DESCRIPTION
Adds originalIds to scenery objects that were missing them, so now you can save them to td6/td7 designs.

![ksnip_20260316-194458](https://github.com/user-attachments/assets/cffb7db1-b3b0-4b93-9d06-26293fe97946)
![ksnip_20260316-194505](https://github.com/user-attachments/assets/3e60ff6d-deab-4ca0-a80b-c7ee7bc85a55)