### PR TITLE
Remove supports from pirate ship

### DIFF
--- a/objects/rct2/scenery_group/rct2.scenery_group.scgpirat.json
+++ b/objects/rct2/scenery_group/rct2.scenery_group.scgpirat.json
@@ -11,7 +11,7 @@
     "properties": {
         "entries": [
             "rct2.peep_animations.entertainer_pirate",
-            "rct2.scenery_large.prship",
+            "rct2.scenery_large.prship_fix",
             "rct2.scenery_small.chest1",
             "rct2.scenery_small.chest2",
             "rct2.scenery_wall.wallpr32",

--- a/objects/rct2/scenery_large/rct2.scenery_large.prship.json
+++ b/objects/rct2/scenery_large/rct2.scenery_large.prship.json
@@ -7,10 +7,12 @@
     "version": "1.0",
     "originalId": "0A188C82|PRSHIP  |5CD70D93",
     "sourceGame": "rct2",
+    "isCompatibilityObject": true,
     "objectType": "scenery_large",
     "properties": {
         "price": 190,
         "removalPrice": -150,
+        "sceneryGroup": "rct2ww.scenery_group.scgpirat",
         "cursor": "CURSOR_STATUE_DOWN",
         "isPhotogenic": true,
         "tiles": [

--- a/objects/rct2/scenery_large/rct2.scenery_large.prship_fix.json
+++ b/objects/rct2/scenery_large/rct2.scenery_large.prship_fix.json
@@ -1,0 +1,104 @@
+{
+    "id": "rct2.scenery_large.prship_fix",
+    "authors": [
+        "Chris Sawyer",
+        "Simon Foster"
+    ],
+    "version": "1.0",
+    "originalId": "00000082|#PRSHIPF|00000000",
+    "sourceGame": "rct2",
+    "objectType": "scenery_large",
+    "properties": {
+        "price": 190,
+        "removalPrice": -150,
+        "cursor": "CURSOR_STATUE_DOWN",
+        "isPhotogenic": true,
+        "tiles": [
+            {
+                "x": 0,
+                "y": 0,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 9
+            },
+            {
+                "x": 0,
+                "y": 32,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 3
+            },
+            {
+                "x": 32,
+                "y": 0,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 8
+            },
+            {
+                "x": 32,
+                "y": 32,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 2
+            },
+            {
+                "x": 64,
+                "y": 0,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 8
+            },
+            {
+                "x": 64,
+                "y": 32,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 2
+            },
+            {
+                "x": 96,
+                "y": 0,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 12
+            },
+            {
+                "x": 96,
+                "y": 32,
+                "clearance": 136,
+                "hasSupports": false,
+                "walls": 6
+            }
+        ]
+    },
+    "images": [
+        "$RCT2:OBJDATA/PRSHIP.DAT[0..35]"
+    ],
+    "strings": {
+        "name": {
+            "en-GB": "Pirate Ship",
+            "fr-FR": "Bateau pirate",
+            "de-DE": "Piratenschiff",
+            "es-ES": "Barco pirata",
+            "it-IT": "Nave dei pirati",
+            "nl-NL": "Piratenschip",
+            "sv-SE": "Piratskepp",
+            "ko-KR": "해적선",
+            "zh-CN": "海盗船",
+            "zh-TW": "海盜船",
+            "pt-BR": "Navio Pirata",
+            "cs-CZ": "Pirátská loď",
+            "ja-JP": "海賊船",
+            "nb-NO": "Piratskip",
+            "pl-PL": "Okręt piracki",
+            "ru-RU": "Пиратский корабль",
+            "eo-ZZ": "Pirato-ŝipo",
+            "ca-ES": "Vaixell pirata",
+            "fi-FI": "Merirosvolaiva",
+            "ar-EG": "سفينة قراصنة",
+            "gl-ES": "Barco pirata",
+            "hu-HU": "Kalózhajó"
+        }
+    }
+}


### PR DESCRIPTION
Removes support rendering from the pirate ship large scenery object with the usual new object + mark old as compat approach to ensure old parks still render as expected.
Left: New
Right: Old
<img width="1920" height="1080" alt="ksnip_20260420-125843" src="https://github.com/user-attachments/assets/6d6bb5c9-e4e9-4ff3-afd8-d5ea21bfa439" />
