### PR TITLE
pl-PL: Fix misconverted regional characters

### DIFF
--- a/objects/rct2/ride/rct2.ride.submar.json
+++ b/objects/rct2/ride/rct2.ride.submar.json
@@ -120,7 +120,7 @@
             "pt-BR": "5 passageiros por submarino",
             "cs-CZ": "5 míst v každé ponorce",
             "ja-JP": "各鑑5名",
-            "pl-PL": "5 pasażerów na łódţ podwodną",
+            "pl-PL": "5 pasażerów na łódź podwodną",
             "ru-RU": "5 пассажиров на машину",
             "eo-ZZ": "Po 5 pasaĝeroj por submarŝipo",
             "ca-ES": "5 passatgers per submarí",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tgc1.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tgc1.json
@@ -37,7 +37,7 @@
             "pt-BR": "Escultura",
             "cs-CZ": "Socha",
             "ja-JP": "彫刻",
-            "pl-PL": "Rzeţba",
+            "pl-PL": "Rzeźba",
             "ru-RU": "Скульптура",
             "fr-FR": "Sculpture",
             "eo-ZZ": "Skulptaĵo",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tgc2.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tgc2.json
@@ -37,7 +37,7 @@
             "pt-BR": "Escultura",
             "cs-CZ": "Socha",
             "ja-JP": "彫刻",
-            "pl-PL": "Rzeţba",
+            "pl-PL": "Rzeźba",
             "ru-RU": "Скульптура",
             "fr-FR": "Sculpture",
             "eo-ZZ": "Skulptaĵo",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tge1.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tge1.json
@@ -41,7 +41,7 @@
             "pt-BR": "Escultura Geométrica",
             "cs-CZ": "Geometrická socha",
             "ja-JP": "幾何学的彫刻",
-            "pl-PL": "Rzeţba geometryczna",
+            "pl-PL": "Rzeźba geometryczna",
             "ru-RU": "Геометрическая скульптура",
             "eo-ZZ": "Geometria skulptaĵo",
             "ca-ES": "Escultura geomètrica",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tge2.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tge2.json
@@ -42,7 +42,7 @@
             "pt-BR": "Escultura Geométrica",
             "cs-CZ": "Geometrická socha",
             "ja-JP": "幾何学的彫刻",
-            "pl-PL": "Rzeţba geometryczna",
+            "pl-PL": "Rzeźba geometryczna",
             "ru-RU": "Геометрическая скульптура",
             "eo-ZZ": "Geometria skulptaĵo",
             "ca-ES": "Escultura geomètrica",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tge3.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tge3.json
@@ -44,7 +44,7 @@
             "pt-BR": "Escultura Geométrica",
             "cs-CZ": "Geometrická socha",
             "ja-JP": "幾何学的彫刻",
-            "pl-PL": "Rzeţba geometryczna",
+            "pl-PL": "Rzeźba geometryczna",
             "ru-RU": "Геометрическая скульптура",
             "eo-ZZ": "Geometria skulptaĵo",
             "ca-ES": "Escultura geomètrica",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tge4.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tge4.json
@@ -41,7 +41,7 @@
             "pt-BR": "Escultura Geométrica",
             "cs-CZ": "Geometrická socha",
             "ja-JP": "幾何学的彫刻",
-            "pl-PL": "Rzeţba geometryczna",
+            "pl-PL": "Rzeźba geometryczna",
             "ru-RU": "Геометрическая скульптура",
             "eo-ZZ": "Geometria skulptaĵo",
             "ca-ES": "Escultura geomètrica",

--- a/objects/rct2/scenery_small/rct2.scenery_small.tge5.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.tge5.json
@@ -42,7 +42,7 @@
             "pt-BR": "Escultura Geométrica",
             "cs-CZ": "Geometrická socha",
             "ja-JP": "幾何学的彫刻",
-            "pl-PL": "Rzeţba geometryczna",
+            "pl-PL": "Rzeźba geometryczna",
             "ru-RU": "Геометрическая скульптура",
             "eo-ZZ": "Geometria skulptaĵo",
             "ca-ES": "Escultura geomètrica",

--- a/objects/rct2/scenery_small/rct2.scenery_small.thrs.json
+++ b/objects/rct2/scenery_small/rct2.scenery_small.thrs.json
@@ -40,7 +40,7 @@
             "pt-BR": "Estátua de Cavaleiro",
             "cs-CZ": "Socha jezdce",
             "ja-JP": "騎手の像",
-            "pl-PL": "Posąg jeţdţca",
+            "pl-PL": "Posąg jeźdźca",
             "ru-RU": "Статуя всадника",
             "eo-ZZ": "Statuo de ĉevalrajdanto",
             "ca-ES": "Estàtua de genet",

--- a/objects/rct2tt/ride/rct2tt.ride.jetpackx.json
+++ b/objects/rct2tt/ride/rct2tt.ride.jetpackx.json
@@ -104,7 +104,7 @@
             "pt-BR": "Vagões grandes com formatos de jetpack para a montanha russa de queda livre invertida",
             "ja-JP": "逆向きに落下する、大型のジェットパックコースター車両です",
             "cs-CZ": "Velké vozidlo, ve stylu jetpacku, nebo-li tryskového batohu, určené pro Horskou dráhu s volným pádem pozpátku",
-            "pl-PL": "Pasażerowie podróżują w pojeţdzie wystrzeliwanym na pionowy odcinek toru",
+            "pl-PL": "Pasażerowie podróżują w pojeździe wystrzeliwanym na pionowy odcinek toru",
             "ru-RU": "Большая машина в форме реактивного рюкзака для реверсивных аттракицонов",
             "eo-ZZ": "Granda rakettornistro-forma ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
             "ca-ES": "Cotxe gran tematitzat com a motxilla de propulsió per a la Caiguda Lliure Invertida.",

--- a/objects/rct2tt/ride/rct2tt.ride.spokprsn.json
+++ b/objects/rct2tt/ride/rct2tt.ride.spokprsn.json
@@ -307,7 +307,7 @@
             "ja-JP": "不気味な地下牢や投獄された者たちのマネキンがいるお化け屋敷です",
             "pt-BR": "Prédio contendo calabouços e manequins de pessoas encarceradas, para assustar os visitantes",
             "cs-CZ": "Budova s bludištěm a figurínami vězňů, kde procházející návštěvníci zažijí pocit strachu",
-            "pl-PL": "Budynek z lochami i manekinami przedstawiającymi więţniów, które mają straszyć odwiedzających",
+            "pl-PL": "Budynek z lochami i manekinami przedstawiającymi więźniów, które mają straszyć odwiedzających",
             "ru-RU": "Здание с манекенами заключенных, пугающих проходящих через него людей",
             "eo-ZZ": "Konstruaĵo, kiu enhavas malliberejojn kaj manekenojn de enprizonigitaj uloj, por timigi homojn irante tra tie",
             "ca-ES": "Edifici que conté masmorres i maniquins de figures empresonades, per fer por a la gent que el visiti.",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth01.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth01.json
@@ -60,7 +60,7 @@
             "zh-TW": "天國浴場水池",
             "pt-BR": "Piscina de Banho Celestial",
             "cs-CZ": "Nebeská koupel - bazén",
-            "pl-PL": "Sadzawka niebiańskich łaţni",
+            "pl-PL": "Sadzawka niebiańskich łaźni",
             "ru-RU": "Бассейн «Райская ванна»",
             "ja-JP": "天空の浴場　プール",
             "eo-ZZ": "Baseno de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth02.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth02.json
@@ -60,7 +60,7 @@
             "zh-TW": "天國浴場水池牆角",
             "pt-BR": "Canto de Piscina de Banho Celestial",
             "cs-CZ": "Nebeská koupel - roh bazénu",
-            "pl-PL": "Narożnik sadzawki niebiańskich łaţni",
+            "pl-PL": "Narożnik sadzawki niebiańskich łaźni",
             "ru-RU": "Угол бассейна «Райская ванна»",
             "ja-JP": "天空の浴場　プール　コーナー",
             "eo-ZZ": "Angulo de baseno de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth03.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth03.json
@@ -59,7 +59,7 @@
             "zh-TW": "天國浴場噴泉",
             "pt-BR": "Chafariz de Banho Celestial",
             "cs-CZ": "Nebeská koupel - fontána",
-            "pl-PL": "Fontanna niebiańskich łaţni",
+            "pl-PL": "Fontanna niebiańskich łaźni",
             "ru-RU": "Фонтан «Райская ванна»",
             "ja-JP": "天空の浴場　噴水",
             "eo-ZZ": "Fontano de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth04.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth04.json
@@ -59,7 +59,7 @@
             "zh-TW": "天國浴場噴泉",
             "pt-BR": "Chafariz de Banho Celestial",
             "cs-CZ": "Nebeská koupel - fontána",
-            "pl-PL": "Fontanna niebiańskich łaţni",
+            "pl-PL": "Fontanna niebiańskich łaźni",
             "ru-RU": "Фонтан «Райская ванна»",
             "ja-JP": "天空の浴場　噴水",
             "eo-ZZ": "Fontano de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth05.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth05.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場拱門",
             "pt-BR": "Arco de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Oblouk",
-            "pl-PL": "Arkada niebiańskich łaţni",
+            "pl-PL": "Arkada niebiańskich łaźni",
             "ru-RU": "Арка «Райская ванна»",
             "ja-JP": "天空の浴場　アーチ",
             "eo-ZZ": "Arkaĵo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth06.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth06.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場拱門",
             "pt-BR": "Arco de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Oblouk",
-            "pl-PL": "Arkada niebiańskich łaţni",
+            "pl-PL": "Arkada niebiańskich łaźni",
             "ru-RU": "Арка «Райская ванна»",
             "ja-JP": "天空の浴場　アーチ",
             "eo-ZZ": "Arkaĵo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth07.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth07.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場拱門",
             "pt-BR": "Arco de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Oblouk",
-            "pl-PL": "Arkada niebiańskich łaţni",
+            "pl-PL": "Arkada niebiańskich łaźni",
             "ru-RU": "«Райская ванна»",
             "ja-JP": "天空の浴場　アーチ",
             "eo-ZZ": "Arkaĵo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth08.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth08.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場樓梯",
             "pt-BR": "Escadaria de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Schodiště",
-            "pl-PL": "Schody niebiańskich łaţni",
+            "pl-PL": "Schody niebiańskich łaźni",
             "ru-RU": "Лестница «Райская ванна»",
             "ja-JP": "天空の浴場　階段",
             "eo-ZZ": "Ŝtuparo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth09.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth09.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場樓梯",
             "pt-BR": "Escadaria de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Schodiště",
-            "pl-PL": "Schody niebiańskich łaţni",
+            "pl-PL": "Schody niebiańskich łaźni",
             "ru-RU": "Лестница «Райская ванна»",
             "ja-JP": "天空の浴場　階段",
             "eo-ZZ": "Ŝtuparo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth10.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth10.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場建築式樣",
             "pt-BR": "Arquitetura de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Architektura",
-            "pl-PL": "Architektura niebiańskich łaţni",
+            "pl-PL": "Architektura niebiańskich łaźni",
             "ru-RU": "Архитектура «Райская ванна»",
             "ja-JP": "天空の浴場　建築",
             "eo-ZZ": "Arĥitekturo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth11.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth11.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場建築式樣",
             "pt-BR": "Arquitetura de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Architektura",
-            "pl-PL": "Architektura niebiańskich łaţni",
+            "pl-PL": "Architektura niebiańskich łaźni",
             "ru-RU": "Архитектура «Райская ванна»",
             "ja-JP": "天空の浴場　建築",
             "eo-ZZ": "Arĥitekturo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth12.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth12.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場建築式樣",
             "pt-BR": "Arquitetura de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Architektura",
-            "pl-PL": "Architektura niebiańskich łaţni",
+            "pl-PL": "Architektura niebiańskich łaźni",
             "ru-RU": "Архитектура «Райская ванна»",
             "ja-JP": "天空の浴場　建築",
             "eo-ZZ": "Arĥitekturo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth13.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth13.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場建築式樣",
             "pt-BR": "Arquitetura de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Architektura",
-            "pl-PL": "Architektura niebiańskich łaţni",
+            "pl-PL": "Architektura niebiańskich łaźni",
             "ru-RU": "Архитектура «Райская ванна»",
             "ja-JP": "天空の浴場　建築",
             "eo-ZZ": "Arĥitekturo de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth14.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth14.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場窗",
             "pt-BR": "Janela de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Okno",
-            "pl-PL": "Okno niebiańskich łaţni",
+            "pl-PL": "Okno niebiańskich łaźni",
             "ru-RU": "Окно «Райская ванна»",
             "ja-JP": "天空の浴場　窓",
             "eo-ZZ": "Fenestro de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth15.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth15.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場地板",
             "pt-BR": "Piso de Banho Celestial",
             "cs-CZ": "Nebeská koupel - Podlaha",
-            "pl-PL": "Posadzka niebiańskich łaţni",
+            "pl-PL": "Posadzka niebiańskich łaźni",
             "ru-RU": "Пол «Райская ванна»",
             "ja-JP": "天空の浴場　床",
             "eo-ZZ": "Planko de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth16.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth16.json
@@ -60,7 +60,7 @@
             "zh-TW": "天國浴場水池台階",
             "pt-BR": "Degraus de Piscina de Banho Celestial",
             "cs-CZ": "Nebeská koupel - schody do bazénu",
-            "pl-PL": "Schody do sadzawki niebiańskich łaţni",
+            "pl-PL": "Schody do sadzawki niebiańskich łaźni",
             "ru-RU": "Лестница в бассейн «Райская ванна»",
             "ja-JP": "天空の浴場　プール　段差",
             "eo-ZZ": "Ŝtupoj de baseno de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth17.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevbth17.json
@@ -60,7 +60,7 @@
             "zh-TW": "天國浴場水池邊緣",
             "pt-BR": "Borda de Piscina de Banho Celestial",
             "cs-CZ": "Nebeská koupel - hrana bazénu",
-            "pl-PL": "Brzeg sadzawki niebiańskich łaţni",
+            "pl-PL": "Brzeg sadzawki niebiańskich łaźni",
             "ru-RU": "Край бассейна «Райская ванна»",
             "ja-JP": "天空の浴場　プール　角",
             "eo-ZZ": "Bordo de baseno de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof01.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof01.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場天花板",
             "pt-BR": "Teto de Banho Celestial",
             "cs-CZ": "Nebeská koupel - střecha",
-            "pl-PL": "Dach niebiańskich łaţni",
+            "pl-PL": "Dach niebiańskich łaźni",
             "ru-RU": "Крыша «Райская ванна»",
             "ja-JP": "天空の浴場　屋根",
             "eo-ZZ": "Tegmento de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof02.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof02.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場天花板",
             "pt-BR": "Teto de Banho Celestial",
             "cs-CZ": "Nebeská koupel - střecha",
-            "pl-PL": "Dach niebiańskich łaţni",
+            "pl-PL": "Dach niebiańskich łaźni",
             "ru-RU": "Крыша «Райская ванна»",
             "ja-JP": "天空の浴場　屋根",
             "eo-ZZ": "Tegmento de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof03.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof03.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場天花板",
             "pt-BR": "Teto de Banho Celestial",
             "cs-CZ": "Nebeská koupel - střecha",
-            "pl-PL": "Dach niebiańskich łaţni",
+            "pl-PL": "Dach niebiańskich łaźni",
             "ru-RU": "Крыша «Райская ванна»",
             "ja-JP": "天空の浴場　屋根",
             "eo-ZZ": "Tegmento de ĉiela bano",

--- a/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof04.json
+++ b/objects/rct2tt/scenery_small/rct2tt.scenery_small.hevrof04.json
@@ -37,7 +37,7 @@
             "zh-TW": "天國浴場天花板",
             "pt-BR": "Teto de Banho Celestial",
             "cs-CZ": "Nebeská koupel - střecha",
-            "pl-PL": "Dach niebiańskich łaţni",
+            "pl-PL": "Dach niebiańskich łaźni",
             "ru-RU": "Крыша «Райская ванна»",
             "ja-JP": "天空の浴場　屋根",
             "eo-ZZ": "Tegmento de ĉiela bano",

--- a/tools/objexport/Localisation.fs
+++ b/tools/objexport/Localisation.fs
@@ -130,6 +130,7 @@ module Localisation =
             match language with
             | "ja-JP" -> 932
             | "ko-KR" -> 949
+            | "pl-PL" -> 1250
             | "zh-CN" -> 936
             | "zh-TW" -> 950
             | _ -> 1252

--- a/tools/objexport/ObjectExporter.fs
+++ b/tools/objexport/ObjectExporter.fs
@@ -118,6 +118,7 @@ module ObjectExporter =
         | 9 -> "ko-KR"
         | 10 -> "zh-CN"
         | 11 -> "zh-TW"
+        | 12 -> "pl-PL"
         | 13 -> "pt-BR"
         | i -> i.ToString()
 


### PR DESCRIPTION
Excluding mapping `pl-PL` to cp1250 in objexport (though I doubt that makes *any* difference, given Polish strings were extracted using a different method), this is a mirror of OpenRCT2/Localisation#3459.