### PR TITLE
Replace “Kremlin” reference with “St. Basil’s Cathedral”

### DIFF
--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml08.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml08.json
@@ -43,7 +43,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Large Tower Base",
+            "en-GB": "St. Basil’s Cathedral Large Tower Base",
             "fr-FR": "Base de grande tour du Kremlin",
             "de-DE": "Kreml - Großer Turm - Basis",
             "es-ES": "Base de torre grande del Kremlin",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml09.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml09.json
@@ -45,7 +45,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Large Tower Top",
+            "en-GB": "St. Basil’s Cathedral Large Tower Top",
             "fr-FR": "Sommet de grande tour du Kremlin",
             "de-DE": "Kreml - Großer Turm - Spitze",
             "es-ES": "Cima de torre grande de Kremlin",

--- a/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml10.json
+++ b/objects/rct2ww/scenery_large/rct2ww.scenery_large.rkreml10.json
@@ -43,7 +43,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Large Tower Mid-Section",
+            "en-GB": "St. Basil’s Cathedral Large Tower Mid-Section",
             "fr-FR": "Section moyenne de grande tour du Kremlin",
             "de-DE": "Kreml - Großer Turm - Mitte",
             "es-ES": "Sección intermedia de torre grande de Kremlin",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml01.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Minaret Piece 1",
+            "en-GB": "St. Basil’s Cathedral Minaret Piece 1",
             "fr-FR": "Pièce de dôme du Kremlin 1",
             "de-DE": "Kreml - Zwiebelkuppel-Bauteil 1",
             "es-ES": "Pieza de cúpula del Kremlin 1",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml02.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Minaret Piece 2",
+            "en-GB": "St. Basil’s Cathedral Minaret Piece 2",
             "fr-FR": "Pièce de dôme du Kremlin 2",
             "de-DE": "Kreml - Zwiebelkuppel-Bauteil 2",
             "es-ES": "Pieza de cúpula del Kremlin 2",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml03.json
@@ -24,7 +24,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Minaret Piece 3",
+            "en-GB": "St. Basil’s Cathedral Minaret Piece 3",
             "fr-FR": "Pièce de dôme du Kremlin 3",
             "de-DE": "Kreml - Zwiebelkuppel-Bauteil 3",
             "es-ES": "Pieza de cúpula del Kremlin 3",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml04.json
@@ -24,7 +24,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Roof Piece 1",
+            "en-GB": "St. Basil’s Cathedral Roof Piece 1",
             "fr-FR": "Pan de toit du Kremlin 1",
             "de-DE": "Kreml - Dach-Bauteil 1",
             "es-ES": "Pieza de tejado del Kremlin 1",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml05.json
@@ -24,7 +24,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Roof Piece 2",
+            "en-GB": "St. Basil’s Cathedral Roof Piece 2",
             "fr-FR": "Pan de toit du Kremlin 2",
             "de-DE": "Kreml - Dach-Bauteil 2",
             "es-ES": "Pieza de tejado del Kremlin 2",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml06.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Small Tower Mid-Section",
+            "en-GB": "St. Basil’s Cathedral Small Tower Mid-Section",
             "fr-FR": "Section moyenne de petite tour du Kremlin",
             "de-DE": "Kreml - Kleiner Turm - Mitte",
             "es-ES": "Sección intermedia de torre pequeña del Kremlin",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml07.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml07.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Small Tower Base",
+            "en-GB": "St. Basil’s Cathedral Small Tower Base",
             "fr-FR": "Base de petite tour du Kremlin",
             "de-DE": "Kreml - Kleiner Turm - Basis",
             "es-ES": "Base de torre pequeña del Kremlin",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml11.json
@@ -24,7 +24,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Small Tower Minaret Base",
+            "en-GB": "St. Basil’s Cathedral Small Tower Minaret Base",
             "fr-FR": "Base de petite tour de dôme du Kremlin",
             "de-DE": "Kreml - Kleiner Turm - Zwiebelkuppel-Basis",
             "es-ES": "Base de cúpula pequeña del Kremlin",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml01.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Step-up Wall Piece 1",
+            "en-GB": "St. Basil’s Cathedral Step-up Wall Piece 1",
             "fr-FR": "Pan de mur de montée du Kremlin 1",
             "de-DE": "Kreml - Treppen-Wandbauteil 1",
             "es-ES": "Pieza de pared de sección de escaleras del Kremlin 1",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml02.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Step-up Wall Piece 2",
+            "en-GB": "St. Basil’s Cathedral Step-up Wall Piece 2",
             "fr-FR": "Pan de mur de montée du Kremlin 2",
             "de-DE": "Kreml - Treppen-Wandbauteil 2",
             "es-ES": "Pieza de pared de sección de escaleras del Kremlin 2",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml03.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 1",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 1",
             "fr-FR": "Pan de mur du Kremlin 1",
             "de-DE": "Kreml - Wandbauteil 1",
             "es-ES": "Pieza de pared del Kremlin 1",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml04.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 2",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 2",
             "fr-FR": "Pan de mur du Kremlin 2",
             "de-DE": "Kreml - Wandbauteil 2",
             "es-ES": "Pieza de pared del Kremlin 2",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml05.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 3",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 3",
             "fr-FR": "Pan de mur du Kremlin 3",
             "de-DE": "Kreml - Wandbauteil 3",
             "es-ES": "Pieza de pared del Kremlin 3",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml06.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.wkreml06.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 4",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 4",
             "fr-FR": "Pan de mur du Kremlin 4",
             "de-DE": "Kreml - Wandbauteil 4",
             "es-ES": "Pieza de pared del Kremlin 4",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml07.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml07.json
@@ -17,7 +17,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 5",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 5",
             "fr-FR": "Pan de mur du Kremlin 5",
             "de-DE": "Kreml - Wandbauteil 5",
             "es-ES": "Pieza de pared del Kremlin 5",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml08.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml08.json
@@ -17,7 +17,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 6",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 6",
             "fr-FR": "Pan de mur du Kremlin 6",
             "de-DE": "Kreml - Wandbauteil 6",
             "es-ES": "Pieza de pared del Kremlin 6",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml09.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml09.json
@@ -17,7 +17,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 7",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 7",
             "fr-FR": "Pan de mur du Kremlin 7",
             "de-DE": "Kreml - Wandbauteil 7",
             "es-ES": "Pieza de pared del Kremlin 7",

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml10.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml10.json
@@ -17,7 +17,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Kremlin Wall Piece 8",
+            "en-GB": "St. Basil’s Cathedral Wall Piece 8",
             "fr-FR": "Pan de mur du Kremlin 8",
             "de-DE": "Kreml - Wandbauteil 8",
             "es-ES": "Pieza de pared del Kremlin 8",


### PR DESCRIPTION
All pieces seem to be inspired by St. Basil’s Cathedral, which is next to the Kremlin, but not part of it. (Together, they count as one World Heritage site.)

For reference, this is that cathedral:

<img width="460" height="700" alt="afbeelding" src="https://github.com/user-attachments/assets/3df8643e-466c-493e-a552-d705b3c089a9" />

And this is the Kremlin:

<img width="1920" height="1285" alt="afbeelding" src="https://github.com/user-attachments/assets/301dc804-dc2f-4bbc-8174-cf0af981a58f" />

I would like confirmation from @andolga that I got this correct.