### PR TITLE
Fix mismatches, minaret > dome, add flat prefix

### DIFF
--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab05.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Small Tower Minaret Base",
+            "en-GB": "Drab Small Tower Dome Base",
             "fr-FR": "Base de petite tour de dôme terne",
             "de-DE": "Düsterer Kleiner Turm - Zwiebelkuppel-Basis",
             "es-ES": "Base de torre pequeña de minareteapagado",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab08.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab08.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Minaret Piece 1",
+            "en-GB": "Drab Dome Piece 1",
             "fr-FR": "Pièce de dôme terne 1",
             "de-DE": "Düsteres Zwiebelkuppel-Bauteil 1",
             "es-ES": "Pieza de minarete apagado 1",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab09.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab09.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Minaret Piece 2",
+            "en-GB": "Drab Dome Piece 2",
             "fr-FR": "Pièce de dôme terne 2",
             "de-DE": "Düsteres Zwiebelkuppel-Bauteil 2",
             "es-ES": "Pieza de minarete apagado 2",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab10.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab10.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Minaret Piece 3",
+            "en-GB": "Drab Dome Piece 3",
             "fr-FR": "Pièce de dôme terne 3",
             "de-DE": "Düsteres Zwiebelkuppel-Bauteil 3",
             "es-ES": "Pieza de minarete apagado 3",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab11.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Roof Piece 1",
+            "en-GB": "Drab Flat Roof Piece 1",
             "fr-FR": "Pan de toit terne 1",
             "de-DE": "Düsteres Dach-Bauteil 1",
             "es-ES": "Pieza de tejado apagado 1",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab12.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab12.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Roof Piece 2",
+            "en-GB": "Drab Flat Roof Piece 2",
             "fr-FR": "Pan de toit terne 2",
             "de-DE": "Düsteres Dach-Bauteil 2",
             "es-ES": "Pieza de tejado apagado 2",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab13.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab13.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Roof Piece 3",
+            "en-GB": "Drab Flat Roof Piece 3",
             "fr-FR": "Pan de toit terne 3",
             "de-DE": "Düsteres Dach-Bauteil 3",
             "es-ES": "Pieza de tejado apagado 3",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab14.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rdrab14.json
@@ -22,7 +22,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "Drab Roof Piece 4",
+            "en-GB": "Drab Flat Roof Piece 4",
             "fr-FR": "Pan de toit terne 4",
             "de-DE": "Düsteres Dach-Bauteil 4",
             "es-ES": "Pieza de tejado apagado 4",

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml01.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml01.json
@@ -22,24 +22,24 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "St. Basil’s Cathedral Minaret Piece 1",
-            "fr-FR": "Pièce de dôme du Kremlin 1",
-            "de-DE": "Kreml - Zwiebelkuppel-Bauteil 1",
-            "es-ES": "Pieza de cúpula del Kremlin 1",
-            "it-IT": "Pezzo di cupola del Cremlino 1",
-            "nl-NL": "Stuk Basiliuskathedraal-Minaret 1",
-            "sv-SE": "Del 1 till Kreml-minarettorn",
-            "cs-CZ": "Kremlinský Minaret díl 1",
-            "ko-KR": "크렘린 성탑 조각 1",
-            "pl-PL": "Część wieżyczki kremlowskiej 1",
-            "ru-RU": "Кремлёвский минарет 1",
-            "pt-BR": "Peça de Minarete do Kremlin 1",
-            "ja-JP": "クレムリン　ミナレット部分1",
-            "eo-ZZ": "Minareto de Kremlo, parto 1",
-            "ca-ES": "Part del minaret del Kremlin 1",
-            "fi-FI": "Kremlinin minareetin osa 1",
-            "zh-CN": "克里姆林宫-宣礼塔1",
-            "gl-ES": "Peza 1 de Minarete do Kremlin"
+            "en-GB": "St. Basil’s Cathedral Flat Roof Piece 1",
+            "fr-FR": "Pan de toit du Kremlin 1",
+            "de-DE": "Kreml - Dach-Bauteil 1",
+            "es-ES": "Pieza de tejado del Kremlin 1",
+            "it-IT": "Pezzo di tetto del Cremlino 1",
+            "nl-NL": "Stuk dak Basiliuskathedraal 1",
+            "sv-SE": "Takdel 1 till Kreml-torn",
+            "cs-CZ": "Kremlinská střecha díl 1",
+            "ko-KR": "크렘린 지붕 조각 1",
+            "pl-PL": "Segment dachu kremlowskiego 1",
+            "ru-RU": "Кремлёвская крыша 1",
+            "pt-BR": "Peça de Telhado do Kremlin 1",
+            "ja-JP": "クレムリン　屋根部分1",
+            "eo-ZZ": "Tegmento de Kremlo, parto 1",
+            "ca-ES": "Part de la teulada del Kremlin 1",
+            "fi-FI": "Kremlinin katon osa 1",
+            "zh-CN": "克里姆林宫-房顶1",
+            "gl-ES": "Peza 1 de Teito do Kremlin"
         }
     }
 }

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml02.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml02.json
@@ -22,24 +22,24 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "St. Basil’s Cathedral Minaret Piece 2",
-            "fr-FR": "Pièce de dôme du Kremlin 2",
-            "de-DE": "Kreml - Zwiebelkuppel-Bauteil 2",
-            "es-ES": "Pieza de cúpula del Kremlin 2",
-            "it-IT": "Pezzo di cupola del Cremlino 2",
-            "nl-NL": "Stuk Basiliuskathedraal-Minaret 2",
-            "sv-SE": "Del 2 till Kreml-minarettorn",
-            "cs-CZ": "Kremlinský Minaret díl 2",
-            "ko-KR": "크렘린 성탑 조각 2",
-            "pl-PL": "Część wieżyczki kremlowskiej 2",
-            "ru-RU": "Кремлёвский минарет 2",
-            "pt-BR": "Peça de Minarete do Kremlin 2",
-            "ja-JP": "クレムリン　ミナレット部分2",
-            "eo-ZZ": "Minareto de Kremlo, parto 2",
-            "ca-ES": "Part del minaret del Kremlin 2",
-            "fi-FI": "Kremlinin minareetin osa 2",
-            "zh-CN": "克里姆林宫-宣礼塔2",
-            "gl-ES": "Peza 2 de Minarete do Kremlin"
+            "en-GB": "St. Basil’s Cathedral Flat Roof Piece 2",
+            "fr-FR": "Pan de toit du Kremlin 2",
+            "de-DE": "Kreml - Dach-Bauteil 2",
+            "es-ES": "Pieza de tejado del Kremlin 2",
+            "it-IT": "Pezzo di tetto del Cremlino 2",
+            "nl-NL": "Stuk dak Basiliuskathedraal 2",
+            "sv-SE": "Takdel 2 till Kreml-torn",
+            "cs-CZ": "Kremlinská střecha díl 2",
+            "ko-KR": "크렘린 지붕 조각 2",
+            "pl-PL": "Segment dachu kremlowskiego 2",
+            "ru-RU": "Кремлёвская крыша 2",
+            "pt-BR": "Peça de Telhado do Kremlin 2",
+            "ja-JP": "クレムリン　屋根部分2",
+            "eo-ZZ": "Tegmento de Kremlo, parto 2",
+            "ca-ES": "Part de la teulada del Kremlin 2",
+            "fi-FI": "Kremlinin katon osa 2",
+            "zh-CN": "克里姆林宫-房顶2",
+            "gl-ES": "Peza 2 de Teito do Kremlin"
         }
     }
 }

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml03.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml03.json
@@ -24,24 +24,24 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "St. Basil’s Cathedral Minaret Piece 3",
-            "fr-FR": "Pièce de dôme du Kremlin 3",
-            "de-DE": "Kreml - Zwiebelkuppel-Bauteil 3",
-            "es-ES": "Pieza de cúpula del Kremlin 3",
-            "it-IT": "Pezzo di cupola del Cremlino 3",
-            "nl-NL": "Stuk Basiliuskathedraal-Minaret 3",
-            "sv-SE": "Del 3 till Kreml-minarettorn",
-            "cs-CZ": "Kremlinský Minaret díl 3",
-            "ko-KR": "크렘린 성탑 조각 3",
-            "pl-PL": "Część wieżyczki kremlowskiej 3",
-            "ru-RU": "Кремлёвский минарет 3",
-            "pt-BR": "Peça de Minarete do Kremlin 3",
-            "ja-JP": "クレムリン　ミナレット部分3",
-            "eo-ZZ": "Minareto de Kremlo, parto 3",
-            "ca-ES": "Part del minaret del Kremlin 3",
-            "fi-FI": "Kremlinin minareetin osa 3",
-            "zh-CN": "克里姆林宫-宣礼塔3",
-            "gl-ES": "Peza 3 de Minarete do Kremlin"
+            "en-GB": "St. Basil’s Cathedral Dome Piece 2",
+            "fr-FR": "Pièce de dôme du Kremlin 2",
+            "de-DE": "Kreml - Zwiebelkuppel-Bauteil 2",
+            "es-ES": "Pieza de cúpula del Kremlin 2",
+            "it-IT": "Pezzo di cupola del Cremlino 2",
+            "nl-NL": "Stuk Basiliuskathedraal-Minaret 2",
+            "sv-SE": "Del 2 till Kreml-minarettorn",
+            "cs-CZ": "Kremlinský Minaret díl 2",
+            "ko-KR": "크렘린 성탑 조각 2",
+            "pl-PL": "Część wieżyczki kremlowskiej 2",
+            "ru-RU": "Кремлёвский минарет 2",
+            "pt-BR": "Peça de Minarete do Kremlin 2",
+            "ja-JP": "クレムリン　ミナレット部分2",
+            "eo-ZZ": "Minareto de Kremlo, parto 2",
+            "ca-ES": "Part del minaret del Kremlin 2",
+            "fi-FI": "Kremlinin minareetin osa 2",
+            "zh-CN": "克里姆林宫-宣礼塔2",
+            "gl-ES": "Peza 2 de Minarete do Kremlin"
         }
     }
 }

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml04.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml04.json
@@ -24,24 +24,24 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "St. Basil’s Cathedral Roof Piece 1",
-            "fr-FR": "Pan de toit du Kremlin 1",
-            "de-DE": "Kreml - Dach-Bauteil 1",
-            "es-ES": "Pieza de tejado del Kremlin 1",
-            "it-IT": "Pezzo di tetto del Cremlino 1",
-            "nl-NL": "Stuk dak Basiliuskathedraal 1",
-            "sv-SE": "Takdel 1 till Kreml-torn",
-            "cs-CZ": "Kremlinská střecha díl 1",
-            "ko-KR": "크렘린 지붕 조각 1",
-            "pl-PL": "Segment dachu kremlowskiego 1",
-            "ru-RU": "Кремлёвская крыша 1",
-            "pt-BR": "Peça de Telhado do Kremlin 1",
-            "ja-JP": "クレムリン　屋根部分1",
-            "eo-ZZ": "Tegmento de Kremlo, parto 1",
-            "ca-ES": "Part de la teulada del Kremlin 1",
-            "fi-FI": "Kremlinin katon osa 1",
-            "zh-CN": "克里姆林宫-房顶1",
-            "gl-ES": "Peza 1 de Teito do Kremlin"
+            "en-GB": "St. Basil’s Cathedral Dome Piece 3",
+            "fr-FR": "Pièce de dôme du Kremlin 3",
+            "de-DE": "Kreml - Zwiebelkuppel-Bauteil 3",
+            "es-ES": "Pieza de cúpula del Kremlin 3",
+            "it-IT": "Pezzo di cupola del Cremlino 3",
+            "nl-NL": "Stuk Basiliuskathedraal-Minaret 3",
+            "sv-SE": "Del 3 till Kreml-minarettorn",
+            "cs-CZ": "Kremlinský Minaret díl 3",
+            "ko-KR": "크렘린 성탑 조각 3",
+            "pl-PL": "Część wieżyczki kremlowskiej 3",
+            "ru-RU": "Кремлёвский минарет 3",
+            "pt-BR": "Peça de Minarete do Kremlin 3",
+            "ja-JP": "クレムリン　ミナレット部分3",
+            "eo-ZZ": "Minareto de Kremlo, parto 3",
+            "ca-ES": "Part del minaret del Kremlin 3",
+            "fi-FI": "Kremlinin minareetin osa 3",
+            "zh-CN": "克里姆林宫-宣礼塔3",
+            "gl-ES": "Peza 3 de Minarete do Kremlin"
         }
     }
 }

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml05.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml05.json
@@ -24,24 +24,24 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "St. Basil’s Cathedral Roof Piece 2",
-            "fr-FR": "Pan de toit du Kremlin 2",
-            "de-DE": "Kreml - Dach-Bauteil 2",
-            "es-ES": "Pieza de tejado del Kremlin 2",
-            "it-IT": "Pezzo di tetto del Cremlino 2",
-            "nl-NL": "Stuk dak Basiliuskathedraal 2",
-            "sv-SE": "Takdel 2 till Kreml-torn",
-            "cs-CZ": "Kremlinská střecha díl 2",
-            "ko-KR": "크렘린 지붕 조각 2",
-            "pl-PL": "Segment dachu kremlowskiego 2",
-            "ru-RU": "Кремлёвская крыша 2",
-            "pt-BR": "Peça de Telhado do Kremlin 2",
-            "ja-JP": "クレムリン　屋根部分2",
-            "eo-ZZ": "Tegmento de Kremlo, parto 2",
-            "ca-ES": "Part de la teulada del Kremlin 2",
-            "fi-FI": "Kremlinin katon osa 2",
-            "zh-CN": "克里姆林宫-房顶2",
-            "gl-ES": "Peza 2 de Teito do Kremlin"
+            "en-GB": "St. Basil’s Cathedral Dome Piece 1",
+            "fr-FR": "Pièce de dôme du Kremlin 1",
+            "de-DE": "Kreml - Zwiebelkuppel-Bauteil 1",
+            "es-ES": "Pieza de cúpula del Kremlin 1",
+            "it-IT": "Pezzo di cupola del Cremlino 1",
+            "nl-NL": "Stuk Basiliuskathedraal-Minaret 1",
+            "sv-SE": "Del 1 till Kreml-minarettorn",
+            "cs-CZ": "Kremlinský Minaret díl 1",
+            "ko-KR": "크렘린 성탑 조각 1",
+            "pl-PL": "Część wieżyczki kremlowskiej 1",
+            "ru-RU": "Кремлёвский минарет 1",
+            "pt-BR": "Peça de Minarete do Kremlin 1",
+            "ja-JP": "クレムリン　ミナレット部分1",
+            "eo-ZZ": "Minareto de Kremlo, parto 1",
+            "ca-ES": "Part del minaret del Kremlin 1",
+            "fi-FI": "Kremlinin minareetin osa 1",
+            "zh-CN": "克里姆林宫-宣礼塔1",
+            "gl-ES": "Peza 1 de Minarete do Kremlin"
         }
     }
 }

--- a/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml11.json
+++ b/objects/rct2ww/scenery_small/rct2ww.scenery_small.rkreml11.json
@@ -24,7 +24,7 @@
     ],
     "strings": {
         "name": {
-            "en-GB": "St. Basil’s Cathedral Small Tower Minaret Base",
+            "en-GB": "St. Basil’s Cathedral Small Tower Dome Base",
             "fr-FR": "Base de petite tour de dôme du Kremlin",
             "de-DE": "Kreml - Kleiner Turm - Zwiebelkuppel-Basis",
             "es-ES": "Base de cúpula pequeña del Kremlin",


### PR DESCRIPTION
The fixed dome pieces are in the wrong order numerically in the scenery group, but that's because the fixed/drab pieces aren't in the same order. Needs to be fixed later.