### PR TITLE
Fix transparency (for watching rides/scenery) on some walls

### DIFF
--- a/objects/official/scenery_wall/couger.scenery_wall.acww33/object.json
+++ b/objects/official/scenery_wall/couger.scenery_wall.acww33/object.json
@@ -9,6 +9,7 @@
     "sourceGame": "official",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 80,

--- a/objects/official/scenery_wall/mamabear.scenery_wall.mg-prar/object.json
+++ b/objects/official/scenery_wall/mamabear.scenery_wall.mg-prar/object.json
@@ -10,6 +10,7 @@
     "objectType": "scenery_wall",
     "properties": {
         "isDoor": true,
+        "isOpaque": true,
         "height": 4,
         "price": 120,
         "sceneryGroup": "rct2.scenery_group.scgwalls"

--- a/objects/official/scenery_wall/official.scenery_wall.post_flipped.json
+++ b/objects/official/scenery_wall/official.scenery_wall.post_flipped.json
@@ -10,6 +10,7 @@
     "objectType": "scenery_wall",
     "properties": {
         "isBanner": true,
+        "isOpaque": true,
         "hasPrimaryColour": true,
         "height": 4,
         "price": 70

--- a/objects/rct2/scenery_wall/rct2.scenery_wall.wallpost.json
+++ b/objects/rct2/scenery_wall/rct2.scenery_wall.wallpost.json
@@ -10,6 +10,7 @@
     "objectType": "scenery_wall",
     "properties": {
         "isBanner": true,
+        "isOpaque": true,
         "hasPrimaryColour": true,
         "height": 4,
         "price": 70

--- a/objects/rct2/scenery_wall/rct2.scenery_wall.walltxgt.json
+++ b/objects/rct2/scenery_wall/rct2.scenery_wall.walltxgt.json
@@ -10,7 +10,6 @@
     "objectType": "scenery_wall",
     "properties": {
         "isBanner": true,
-        "isOpaque": true,
         "height": 4,
         "price": 100
     },

--- a/objects/rct2tt/scenery_wall/rct2tt.scenery_wall.jailxx19.json
+++ b/objects/rct2tt/scenery_wall/rct2tt.scenery_wall.jailxx19.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2tt",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 10,
         "price": 70,

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wallice7.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wallice7.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wbambo21.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wbambo21.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wcorr13.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wcorr13.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wcorr14.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wcorr14.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wdrab04.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wdrab04.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wdrab08.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wdrab08.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml10.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wkreml10.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wpalm03.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wpalm03.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50

--- a/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wtudor07.json
+++ b/objects/rct2ww/scenery_wall/rct2ww.scenery_wall.wtudor07.json
@@ -8,6 +8,7 @@
     "sourceGame": "rct2ww",
     "objectType": "scenery_wall",
     "properties": {
+        "isOpaque": true,
         "isAllowedOnSlope": true,
         "height": 4,
         "price": 50


### PR DESCRIPTION
Guests may watch interesting rides or scenery, but their view might be blocked by stuff that's in the way. However, some walls are considered transparent (the isOpaque flag is wrongly named and actually denotes transparency instead of opaqueness), allowing guests to see through them anyway.

This PR fixes some illogical decisions for some objects. One wall, the Texas Giant sign, has been made non-transparent, and 14 others that should be transparent but were not, mostly from the WWTT expansions, have been marked as transparent.

Here are all the new transparent walls:
<img width="1356" height="864" alt="image" src="https://github.com/user-attachments/assets/1e577a5f-1edc-474a-bbbf-51bb3533e4ee" />
